### PR TITLE
Point size with distance

### DIFF
--- a/src/math/base.h
+++ b/src/math/base.h
@@ -10,10 +10,19 @@ template <typename T>
 concept Numeric = std::convertible_to<T, double>;
 
 /*! \brief Get the normalized position of val between a and b */
-template <Numeric T>
-inline constexpr auto inverse_lerp(auto a, auto b, T val) {
-  val = std::clamp(val, a, b);
-  return ((abs(val) - a) / (b - a));
+inline constexpr auto inverse_lerp(Numeric auto a,
+                                   Numeric auto b,
+                                   Numeric auto val) {
+  auto aa = static_cast<decltype(val)>(a);
+  auto bb = static_cast<decltype(val)>(b);
+
+  val = std::clamp(val, aa, bb);
+  return ((abs(val) - aa) / (bb - aa));
+}
+
+/*! \brief Wrap the number from 0.0 to 1.0 */
+inline constexpr double wrap(Numeric auto& num) {
+  return num - std::floor(num);
 }
 
 }  // namespace rpg::math

--- a/src/math/base.h
+++ b/src/math/base.h
@@ -2,6 +2,7 @@
 #include <concepts>
 #include <numeric>
 #include <cassert>
+#include <algorithm>
 
 namespace rpg::math {
 
@@ -11,6 +12,7 @@ concept Numeric = std::convertible_to<T, double>;
 /*! \brief Get the normalized position of val between a and b */
 template <Numeric T>
 inline constexpr auto inverse_lerp(auto a, auto b, T val) {
+  val = std::clamp(val, a, b);
   return ((abs(val) - a) / (b - a));
 }
 

--- a/src/particle_simulation.cpp
+++ b/src/particle_simulation.cpp
@@ -48,11 +48,11 @@ void update_particle_position(Particle& p, float time) {
   physics::apply_velocity(p, time);
 
   if (p.pos.y <= 0 && p.velocity.y < 0) {
-    physics::bounce_basic(p, 5.0, get_rand(0.5, 0.6));
+    physics::bounce_basic(p, 5.0, 0.7);
 
     math::inverse_lerp(0.25, 2.0, math::magnitude(p.velocity));
 
-    if (math::magnitude(p.velocity) < 0.25f)
+    if (abs(p.velocity.y) < 4.0f)
       p.lifetime = 0;
     else
       p.lifetime += 3.0f;
@@ -109,7 +109,8 @@ int calc_num_shots(float time_since) {
 }
 
 inline Particle EmitParticle() {
-  const float magnitude = 10.0f;  // get_rand(min_mag, max_mag);
+  const float magnitude =
+      get_rand(5.0f, 15.0f);  // 10.0f;  // get_rand(min_mag, max_mag);
 
   const float horizontal_angle = get_rand(0, 360);
   const float vertical_angle = 15.0f;  // get_rand(0, spread);
@@ -121,16 +122,6 @@ inline Particle EmitParticle() {
   Particle out_particle(origin, white);
   out_particle.velocity = (dir * magnitude);
 
-  // const double mag_intensity = math::inverse_lerp(0, 360, horizontal_angle);
-
-  // float h = mag_intensity * 255.0f;
-  // float s = 1.0f;
-  // float v = 1.0f;
-  // glm::vec3 hsv(h, s, v);
-  // out_particle.color = glm::rgbColor(hsv);
-
-  // out_particle.color = glm::mix(glm::vec3(0, 1, 1), glm::vec3(0, 0.5,
-  // 1), 1.0);
   out_particle.color = {0, 0.25, 1};
   return out_particle;
 }

--- a/src/particle_simulation.cpp
+++ b/src/particle_simulation.cpp
@@ -112,7 +112,7 @@ inline Particle EmitParticle() {
   const float magnitude = 10.0f;  // get_rand(min_mag, max_mag);
 
   const float horizontal_angle = get_rand(0, 360);
-  const float vertical_angle = 25.0f;  // get_rand(0, spread);
+  const float vertical_angle = 15.0f;  // get_rand(0, spread);
 
   auto dir = math::spherical_to_cartesian(glm::vec3(
       1, math::to_radians(horizontal_angle), math::to_radians(vertical_angle)));

--- a/src/physics/rigid_body.h
+++ b/src/physics/rigid_body.h
@@ -30,6 +30,15 @@ inline auto kinematic_energy(const RigidBody auto& body, Numeric auto mass) {
 inline void bounce_basic(RigidBody auto& body,
                          Numeric auto mass = 5.0,
                          Numeric auto e = 0) {
+  // Do nothing if the particle has no vertical momentum
+  const auto y_vel = abs(get(body.velocity, 1));
+  if (y_vel < 0.001) {
+    set(body.velocity, 1, 0);
+    set(body.pos, 1, 0);
+
+    return;
+  }
+
   const Numeric auto energy = kinematic_energy(body, mass);
 
   const auto energy_loss = calculate_energy_loss(e);
@@ -39,5 +48,6 @@ inline void bounce_basic(RigidBody auto& body,
       velocity_from_kinematic_energy(energy_after_bounce, mass);
   set_magnitude(body.velocity, velocity_after_bounce);
   set(body.velocity, 1, -get(body.velocity, 1));
+  set(body.pos, 1, 0);
 }
 }  // namespace rpg::physics

--- a/src/random_manager.cpp
+++ b/src/random_manager.cpp
@@ -1,5 +1,6 @@
 #include <random_manager.h>
 #include <cmath>
+#include <algorithm>
 namespace rpg::simulation {
 float RandomManager::GetRandomNumber() {
   return RNG.GetRandomNumber(RD);
@@ -7,6 +8,7 @@ float RandomManager::GetRandomNumber() {
 
 float RandomManager::random_range(float min, float max) {
   float random_number = GetRandomNumber();
+  random_number = static_cast<float>(math::wrap(random_number));
   return std::lerp(min, max, random_number);
 }
 

--- a/src/random_manager.h
+++ b/src/random_manager.h
@@ -1,22 +1,26 @@
 #include <concepts>
 #include <random>
+#include <algorithm>
+#include <math/base.h>
 
 namespace rpg::simulation {
 
 template <class T>
 class RandomNumberGen {
-  static inline T random_engine = T(0.0, 1.0);
+  static inline T random_engine = T(1);
 
  public:
   template <typename D>
+
   static inline float GetRandomNumber(D& device) {
-    return RandomNumberGen::random_engine(device);
+    const auto number = RandomNumberGen::random_engine(device);
+    return number;
   }
 };
 
 /*! \brief Manages the state of the current random number generator */
 class RandomManager {
-  static RandomNumberGen<std::uniform_real_distribution<>> RNG;
+  static RandomNumberGen<std::extreme_value_distribution<>> RNG;
   inline static std::random_device RD;
 
  public:

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -82,6 +82,7 @@ GLFWwindow* InitWindow() {
   glfwWindowHint(GLFW_RESIZABLE, GL_TRUE);
   glfwWindowHint(GLFW_REFRESH_RATE, 120);
   glfwSetInputMode(window, GLFW_RAW_MOUSE_MOTION, GLFW_TRUE);
+  glEnable(GL_PROGRAM_POINT_SIZE);
 
   printf("Initializing GLEW...\n");
   bool did_init = InitGlew();
@@ -113,7 +114,7 @@ void Scene::Start() {
   glfwSetInputMode(this->current_window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
 
   // Set Point Size
-  glPointSize(10.0f);
+  // glPointSize(10.0f);
 
   // initiate draw loop
   printf("Beginning Draw Loop. \n");

--- a/src/shaders/Particle.frag
+++ b/src/shaders/Particle.frag
@@ -10,5 +10,9 @@ out vec3 color;
 
 void main() {
   // Output color = color of the texture at the specified UV
+  vec2 circCoord = 2.0 * gl_PointCoord - 1.0;
+  if (dot(circCoord, circCoord) > 1.0) {
+    discard;
+  }
   color = particle_color;
 }

--- a/src/shaders/Particle.vert
+++ b/src/shaders/Particle.vert
@@ -11,11 +11,25 @@ out vec3 particle_color;
 // Constants. ModelViewProjection Matrix
 uniform mat4 MVP;
 
+const float point_size = 10.0;
+
+const vec2 g_Resolution = vec2(1280, 720);
+
 void main() {
   // Output position of the vertex, in clip space : MVP * position
   gl_Position = MVP * vec4(vpos, 1);
 
-  // UV of the vertex. No special space for this one.
-  // particle_color = vcolor;
+  float spriteDist;
+
+  if (gl_Position.w == 0.0) {
+    spriteDist = 0.00001;
+  } else {
+    spriteDist = gl_Position.w;
+  }
+
+  gl_PointSize =
+      (((point_size * (g_Resolution.x / g_Resolution.y)) / spriteDist) *
+       (g_Resolution.x / g_Resolution.y));
+
   particle_color = vcolor;
 }


### PR DESCRIPTION
Changes:
- Points are now circles instead of squares
- Points now scale properly in relation to camera position. I.E. the further away the camera is, the smaller they are.
- inverse_lerp can now handle values greater than it's max or less than its minimum. 
- Bouncing with a low velocity will result in the point staying still instead of   sinking through the floor. 
- Demo time scale with time_scale float. 

Issues:
- The particle shader now depends on screen resolution, and isn't updated when the window is resized.