### PR TITLE
Simulation Controls.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,6 @@ find_package(GLM REQUIRED)
 build_depend_from_git(glfw https://github.com/glfw/glfw)
 add_subdirectory(external)
 
-
-
-
 # Setup main
 add_executable(RandomParticleEngine)
 target_sources(RandomParticleEngine
@@ -99,6 +96,10 @@ target_sources(RandomParticleEngine
     src/window/hud/combo.cpp
     src/window/hud/fps_counter.h
     src/window/hud/fps_counter.cpp
+    
+    
+    src/menus/settings.cpp
+    src/menus/settings.h
 
     src/math/vector3d.h
     src/math/units.h

--- a/src/entities/particle_simulation.cpp
+++ b/src/entities/particle_simulation.cpp
@@ -47,22 +47,16 @@ inline float get_rand_nolimits() {
   return RandomManager::GetRandomNumber();
 }
 
+void apply_gravity(Particle& P, float time) {
+  physics::apply_gravity(P, time);
+}
+
 /*! \brief Move particle based on it's velocity */
 void update_particle_position(Particle& p, float time) {
   physics::apply_velocity(p, time);
 
   if (p.pos.y <= 0 && p.velocity.y < 0) {
     physics::bounce_basic(p, 5.0, 0.85f);
-    // p.lifetime -= 1.0f;
-
-    // math::inverse_lerp(0.25, 2.0, math::magnitude(p.velocity));
-
-    /*
-        if (abs(p.velocity.y) < 4.0f)
-          p.lifetime = 0;
-        else
-          p.lifetime += 3.0f;
-    */
   }
 }
 
@@ -71,9 +65,7 @@ bool has_lifetime(const Particle& p) {
   return p.lifetime > 0.0f;
 }
 
-void sim_particle(Particle& p, float time) {
-  p.lifetime -= time;
-
+void update_position(Particle& p, float time) {
   physics::apply_gravity(p, time);
   update_particle_position(p, time);
 }

--- a/src/entities/particle_simulation.cpp
+++ b/src/entities/particle_simulation.cpp
@@ -56,7 +56,7 @@ void update_particle_position(Particle& p, float time) {
   physics::apply_velocity(p, time);
 
   if (p.pos.y <= 0 && p.velocity.y < 0) {
-    physics::bounce_basic(p, 5.0, 0.85f);
+    physics::bounce_basic(p, 5.0, 0.85, 0);
   }
 }
 

--- a/src/entities/particle_simulation.cpp
+++ b/src/entities/particle_simulation.cpp
@@ -54,10 +54,17 @@ void apply_gravity(Particle& P, float time) {
 /*! \brief Move particle based on it's velocity */
 void update_particle_position(Particle& p, float time) {
   physics::apply_velocity(p, time);
+}
 
-  if (p.pos.y <= 0 && p.velocity.y < 0) {
-    physics::bounce_basic(p, 5.0, 0.85, 0);
+bool simple_ground_bounce(Particle& p,
+                          float ground_height,
+                          float e,
+                          float mass) {
+  if (p.pos.y <= ground_height && p.velocity.y < 0) {
+    physics::bounce_basic(p, mass, e, ground_height);
+    return true;
   }
+  return false;
 }
 
 /*! \brief Determine if this particle should die on this frame */

--- a/src/entities/particle_simulation.h
+++ b/src/entities/particle_simulation.h
@@ -12,4 +12,13 @@ void simulate_particles(std::vector<Particle>& P,
                         float lifetime,
                         float timescale = 1.0f);
 
+void sim_particle(Particle& p, float time_diff);
+
+double get_time_since(double last_time);
+
+double get_time();
+
+Particle fire_particle(float magnitude, float vertical_angle, float lifetime);
+
+bool has_lifetime(const Particle& p);
 }  // namespace rpg::simulation

--- a/src/entities/particle_simulation.h
+++ b/src/entities/particle_simulation.h
@@ -14,6 +14,10 @@ void simulate_particles(std::vector<Particle>& P,
 
 void sim_particle(Particle& p, float time_diff);
 
+void apply_gravity(Particle& P, float time);
+
+void update_particle_position(Particle& P, float time);
+
 double get_time_since(double last_time);
 
 double get_time();

--- a/src/entities/particle_simulation.h
+++ b/src/entities/particle_simulation.h
@@ -22,6 +22,11 @@ double get_time_since(double last_time);
 
 double get_time();
 
+bool simple_ground_bounce(Particle& P,
+                          float ground_height,
+                          float e = 0.8f,
+                          float mass = 5.0f);
+
 Particle fire_particle(float magnitude, float vertical_angle, float lifetime);
 
 bool has_lifetime(const Particle& p);

--- a/src/entities/particle_simulation.h
+++ b/src/entities/particle_simulation.h
@@ -6,6 +6,10 @@
 namespace rpg::simulation {
 
 extern float time_scale;
-void simulate_particles(std::vector<Particle>& P);
+void simulate_particles(std::vector<Particle>& P,
+                        float max_particles,
+                        float angle,
+                        float lifetime,
+                        float timescale = 1.0f);
 
 }  // namespace rpg::simulation

--- a/src/entities/particle_system.cpp
+++ b/src/entities/particle_system.cpp
@@ -39,7 +39,9 @@ ParticleEngine::ParticleEngine() {
 }
 
 void ParticleEngine::Update() {
-  simulation::simulate_particles(this->particles);
+  simulation::simulate_particles(this->particles,
+                                 static_cast<float>(this->max_patricles),
+                                 this->angle, this->particle_lifetime, 1.0f);
 }
 
 std::vector<float> ParticleEngine::GetVertexBuffer() const {

--- a/src/entities/particle_system.cpp
+++ b/src/entities/particle_system.cpp
@@ -43,14 +43,14 @@ void UpdateParticle(Particle& P, float time) {
 
 int ParticleEngine::queued_shots(float time_since) {
   // Use overflow from the previous shot queue
-  const float shot_time = this->overflow + time_since;
+  const double shot_time = this->overflow + time_since;
 
   // Calculate the maximum number of shots we can fire in the amount of time
   // since our firerate
   int shots = std::floor(shot_time / fire_rate);
 
   if (shots > 0)
-    overflow = (shot_time - (static_cast<float>(shots) * fire_rate));
+    overflow = (shot_time - (static_cast<double>(shots) * fire_rate));
   else
     overflow += time_since;
 
@@ -85,6 +85,7 @@ void ParticleEngine::create_new_particles(float time) {
 
 ParticleEngine::ParticleEngine() {
   this->particles = std::vector<Particle>();
+  last_update = simulation::get_time();
 }
 
 /*! \brief Remove dead particles from the particle system */
@@ -109,8 +110,9 @@ void ParticleEngine::Update() {
 
     // Create new particles
     create_new_particles(time);
+
+    last_update = simulation::get_time();
   }
-  last_update = simulation::get_time();
 }
 
 std::vector<float> ParticleEngine::GetVertexBuffer() const {

--- a/src/entities/particle_system.cpp
+++ b/src/entities/particle_system.cpp
@@ -2,6 +2,8 @@
 #include <entities\particle_simulation.h>
 
 #include <functional>
+#include <cassert>
+#include <assert.h>
 
 using std::vector;
 namespace rpg {
@@ -83,11 +85,14 @@ void ParticleEngine::emit_particle(int num_particles) {
 }
 
 void ParticleEngine::create_new_particles(float time) {
+  if (NumVertices() >= max_particles)
+    return;
+
   const int num_shots = queued_shots(time);
 
   // Limit max number of particles by max_particles and shot time
-  const int particle_budget = std::min(
-      this->max_particles - static_cast<int>(particles.size()), num_shots);
+  const int remaining_vertices = std::max(max_particles - NumVertices(), 0);
+  const int particle_budget = std::clamp(num_shots, 0, remaining_vertices);
 
   emit_particle(particle_budget);
 }

--- a/src/entities/particle_system.cpp
+++ b/src/entities/particle_system.cpp
@@ -35,10 +35,16 @@ inline vector<float> CreateColorArray(const vector<Particle>& particles) {
   return color_arr;
 }
 
-void UpdateParticle(Particle& P, float time) {
+void UpdateParticle(Particle& P,
+                    float time,
+                    bool enable_bounce = true,
+                    float coeff_of_restitution = 0.8,
+                    float mass = 0.5) {
   P.lifetime -= time;
   simulation::apply_gravity(P, time);
   simulation::update_particle_position(P, time);
+  if (enable_bounce)
+    simulation::simple_ground_bounce(P, 0, coeff_of_restitution);
 }
 
 int ParticleEngine::queued_shots(float time_since) {
@@ -67,7 +73,7 @@ void ParticleEngine::emit_particle(int num_particles) {
     Particle P = simulation::fire_particle(this->magnitude, this->angle,
                                            this->particle_lifetime);
 
-    UpdateParticle(P, sim_time);
+    UpdateParticle(P, sim_time, true, this->coeff_of_restitution);
 
     particles.push_back(P);
   }
@@ -103,7 +109,7 @@ void ParticleEngine::Update() {
   if (time > update_threshold) {
     // Apply simulation step to all particles
     for (auto& p : particles)
-      UpdateParticle(p, time);
+      UpdateParticle(p, time, true, this->coeff_of_restitution);
 
     // Remove dead particles
     remove_particles(this->particles);

--- a/src/entities/particle_system.cpp
+++ b/src/entities/particle_system.cpp
@@ -35,7 +35,12 @@ inline vector<float> CreateColorArray(const vector<Particle>& particles) {
   return color_arr;
 }
 
-/*! \brief calculate the number of new particles to create this frame */
+void UpdateParticle(Particle& P, float time) {
+  P.lifetime -= time;
+  simulation::apply_gravity(P, time);
+  simulation::update_particle_position(P, time);
+}
+
 int ParticleEngine::queued_shots(float time_since) {
   // Use overflow from the previous shot queue
   const float shot_time = this->overflow + time_since;
@@ -62,7 +67,7 @@ void ParticleEngine::emit_particle(int num_particles) {
     Particle P = simulation::fire_particle(this->magnitude, this->angle,
                                            this->particle_lifetime);
 
-    simulation::sim_particle(P, sim_time);
+    UpdateParticle(P, sim_time);
 
     particles.push_back(P);
   }
@@ -80,8 +85,8 @@ void ParticleEngine::create_new_particles(float time) {
 
 ParticleEngine::ParticleEngine() {
   this->particles = std::vector<Particle>();
-  this->last_update = 0;
 }
+
 /*! \brief Remove dead particles from the particle system */
 void remove_particles(std::vector<Particle>& particles) {
   particles.erase(
@@ -92,12 +97,12 @@ void remove_particles(std::vector<Particle>& particles) {
 
 void ParticleEngine::Update() {
   // Get time
-
   float time = simulation::get_time_since(last_update) / 1000.0f;
+
   if (time > update_threshold) {
     // Apply simulation step to all particles
     for (auto& p : particles)
-      simulation::sim_particle(p, time);
+      UpdateParticle(p, time);
 
     // Remove dead particles
     remove_particles(this->particles);
@@ -119,12 +124,5 @@ std::vector<float> ParticleEngine::GetColorBuffer() const {
 int ParticleEngine::NumVertices() const {
   return this->particles.size() * 3;
 }
-/*
-void ParticleEngine::SetCameraPosition(glm::mat4& MVP) {
-  glUniformMatrix4fv(this->shader.mvp, 1, GL_FALSE, &(MVP[0][0]));
-}
-*/
-
-//~ParticleEngine(){
 
 }  // namespace rpg

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -15,6 +15,7 @@ class ParticleEngine : public Entity {
   std::vector<Particle> particles;
   double overflow = 0.0;
   double last_update = 0.0;
+  double update_threshold = 0.00000001;
 
   /*! \brief Determine how many particles should be emitted based on the
    * firerate. */
@@ -27,12 +28,15 @@ class ParticleEngine : public Entity {
   void emit_particle(int num_particles);
 
  public:
+  // EMITTER
   int max_particles = 10000;
+  float fire_rate = 0.001;
   float particle_lifetime = 5.0f;
   float angle = 20.0f;
-  double fire_rate = 0.001;
   float magnitude = 10.0f;
-  double update_threshold = 0.00000001;
+
+  /// PARTICLE
+  float coeff_of_restitution = 0.8f;
 
   /*! \brief Construct the particle engine */
   ParticleEngine();

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -27,6 +27,8 @@ class ParticleEngine : public Entity {
   /*! \brief Emit as many particles as possible */
   void emit_particle(int num_particles);
 
+  void simulate_particles(float time);
+
  public:
   // EMITTER
   int max_particles = 10000;

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -12,14 +12,13 @@ namespace rpg {
 
 class ParticleEngine : public Entity {
   glm::vec3 pos = {0, 0, 0};
-
   std::vector<Particle> particles;
 
+ public:
   int max_patricles = 10000;
   float particle_lifetime = 5.0f;
+  float angle = 20.0f;
 
- private:
- public:
   /*! \brief Construct the particle engine */
   ParticleEngine();
 

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -18,24 +18,30 @@ class ParticleEngine : public Entity {
   double update_threshold = 0.00000001;
 
   /*! \brief Determine how many particles should be emitted based on the
-   * firerate. */
+   * firerate, time since last update, and number of alive particles. */
   int queued_shots(float time_since);
 
-  /*! \brief Emit as many particles as possible */
+  /*! \brief Create and emit particles based on how much time passed.. */
   void create_new_particles(float time);
 
   /*! \brief Emit as many particles as possible */
   void emit_particle(int num_particles);
 
+  /*! \brief Apply simulation to every live particle, detect and remove dead
+   * particles, and create new particles */
   void simulate_particles(float time);
 
  public:
   // EMITTER
-  int max_particles = 10000;
-  float fire_rate = 0.001;
-  float particle_lifetime = 5.0f;
-  float angle = 20.0f;
-  float magnitude = 10.0f;
+  int max_particles =
+      15000;  //< Maximum number of particles alive at any given time
+  float fire_rate =
+      0.001;  //< Minimum delay between the creation of each particle
+  float particle_lifetime = 5.0f;  //< Maximum length of time a particle can be
+                                   // alive before being cleaned up
+  float angle = 20.0f;  //< Angle between y+ and the ground to fire particles in
+  float magnitude = 10.0f;  //< MAgnitude of the initial velocity vector  for
+                            // each new particle.
 
   /// PARTICLE
   float coeff_of_restitution = 0.8f;

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -13,11 +13,29 @@ namespace rpg {
 class ParticleEngine : public Entity {
   glm::vec3 pos = {0, 0, 0};
   std::vector<Particle> particles;
+  float overflow = 0.0f;
+  double last_update = 0.0;
+
+  /*! \brief Determine how many particles should be emitted based on the
+   * firerate. */
+  int queued_shots(float time_since);
+
+  /*! \brief Destroy dead particles from the scene */
+  void collect_dead_particles();
+
+  /*! \brief Emit as many particles as possible */
+  void create_new_particles(float time);
+
+  /*! \brief Emit as many particles as possible */
+  void emit_particle(int num_particles);
 
  public:
-  int max_patricles = 10000;
+  int max_particles = 10000;
   float particle_lifetime = 5.0f;
   float angle = 20.0f;
+  float fire_rate = 0.001f;
+  float magnitude = 10.0f;
+  double update_threshold = 0.000001f;
 
   /*! \brief Construct the particle engine */
   ParticleEngine();

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -13,15 +13,12 @@ namespace rpg {
 class ParticleEngine : public Entity {
   glm::vec3 pos = {0, 0, 0};
   std::vector<Particle> particles;
-  float overflow = 0.0f;
+  double overflow = 0.0;
   double last_update = 0.0;
 
   /*! \brief Determine how many particles should be emitted based on the
    * firerate. */
   int queued_shots(float time_since);
-
-  /*! \brief Destroy dead particles from the scene */
-  void collect_dead_particles();
 
   /*! \brief Emit as many particles as possible */
   void create_new_particles(float time);
@@ -33,9 +30,9 @@ class ParticleEngine : public Entity {
   int max_particles = 10000;
   float particle_lifetime = 5.0f;
   float angle = 20.0f;
-  float fire_rate = 0.001f;
+  double fire_rate = 0.001;
   float magnitude = 10.0f;
-  double update_threshold = 0.000001f;
+  double update_threshold = 0.00000001;
 
   /*! \brief Construct the particle engine */
   ParticleEngine();

--- a/src/menus/settings.cpp
+++ b/src/menus/settings.cpp
@@ -4,6 +4,7 @@
 #include <window/hud/hud_window.h>
 
 #include <entities/particle_simulation.h>
+#include <entities/particle_system.h>
 
 #include <window/hud/label.h>
 #include <window/hud/slider.h>
@@ -15,14 +16,19 @@ using std::string;
 using std::vector;
 namespace rpg::menus {
 
-std::string GetParticleCount(const ParticleEngine* ps) {
+std::string GetParticleCount(ParticleEngine* ps) {
   return "Particle Count: " + std::to_string(ps->NumVertices());
 }
 
-void InitParticleMenu(const rpg::ParticleEngine* PE) {
-  vector<Widget*> options_widgets = {new Slider("Simulation Timescale",
-                                                "Simulation Timescale",
-                                                &rpg::simulation::time_scale)};
+void InitParticleMenu(rpg::ParticleEngine* PE) {
+  vector<Widget*> options_widgets = {
+      new Label("Simulation", "Simulation"),
+      new Slider("Simulation Timescale", &rpg::simulation::time_scale),
+
+      new Label("Particle System", "Particle System"),
+      new Slider("Number of Particles", &PE->max_patricles, 1, 100000),
+      new Slider("Particle Lifetime", &PE->particle_lifetime, 0.1, 60),
+      new Slider("Horizontal Angle", &PE->angle, 0, 90)};
 
   vector<Widget*> fps_widgets{
       new FPSCounter("FrameCounter"),
@@ -36,5 +42,5 @@ void InitParticleMenu(const rpg::ParticleEngine* PE) {
   HudManager::CreateWindow("Performance Metrics", 0, 640, true);
   for (const auto& widget : fps_widgets)
     HudManager::AddWidget("Performance Metrics", widget);
-}
+}  // namespace rpg::menus
 }  // namespace rpg::menus

--- a/src/menus/settings.cpp
+++ b/src/menus/settings.cpp
@@ -31,7 +31,7 @@ void InitParticleMenu(rpg::ParticleEngine* PE) {
       new Slider("Particle Lifetime", &PE->particle_lifetime, 0.1, 10),
       new Slider("Horizontal Angle", &PE->angle, 0, 85),
       new Slider("Magnitude", &PE->magnitude, 1, 20),
-      new Slider("Fire Rate", &PE->fire_rate, 0.00001, 0.1),
+      new Slider("Fire Rate", &PE->fire_rate, 0.001, 0.1),
 
       new Label("Particle Physics", "Particle Physics"),
       new Slider("CoR", &PE->coeff_of_restitution, 0, 1)};

--- a/src/menus/settings.cpp
+++ b/src/menus/settings.cpp
@@ -23,12 +23,18 @@ std::string GetParticleCount(ParticleEngine* ps) {
 void InitParticleMenu(rpg::ParticleEngine* PE) {
   vector<Widget*> options_widgets = {
       new Label("Simulation", "Simulation"),
-      new Slider("Simulation Timescale", &rpg::simulation::time_scale),
+      new Slider("Simulation Timescale", &rpg::simulation::time_scale, 0.0f,
+                 2.0f),
 
       new Label("Particle System", "Particle System"),
       new Slider("Number of Particles", &PE->max_particles, 1, 100000),
-      new Slider("Particle Lifetime", &PE->particle_lifetime, 0.1, 60),
-      new Slider("Horizontal Angle", &PE->angle, 0, 90)};
+      new Slider("Particle Lifetime", &PE->particle_lifetime, 0.1, 10),
+      new Slider("Horizontal Angle", &PE->angle, 0, 85),
+      new Slider("Magnitude", &PE->magnitude, 1, 20),
+      new Slider("Fire Rate", &PE->fire_rate, 0.00001, 0.1),
+
+      new Label("Particle Physics", "Particle Physics"),
+      new Slider("CoR", &PE->coeff_of_restitution, 0, 1)};
 
   vector<Widget*> fps_widgets{
       new FPSCounter("FrameCounter"),

--- a/src/menus/settings.cpp
+++ b/src/menus/settings.cpp
@@ -26,7 +26,7 @@ void InitParticleMenu(rpg::ParticleEngine* PE) {
       new Slider("Simulation Timescale", &rpg::simulation::time_scale),
 
       new Label("Particle System", "Particle System"),
-      new Slider("Number of Particles", &PE->max_patricles, 1, 100000),
+      new Slider("Number of Particles", &PE->max_particles, 1, 100000),
       new Slider("Particle Lifetime", &PE->particle_lifetime, 0.1, 60),
       new Slider("Horizontal Angle", &PE->angle, 0, 90)};
 

--- a/src/menus/settings.cpp
+++ b/src/menus/settings.cpp
@@ -1,0 +1,37 @@
+#include <menus\settings.h>
+
+#include <window/hud_manager.h>
+#include <window/hud/hud_window.h>
+
+#include <entities/particle_simulation.h>
+
+#include <window/hud/label.h>
+#include <window/hud/slider.h>
+#include <window/hud/button.h>
+#include <window/hud/fps_counter.h>
+
+namespace rpg::menus {
+
+std::string GetParticleCount(const ParticleEngine* ps) {
+  return "Particle Count: " + std::to_string(ps->NumVertices());
+}
+
+void InitParticleMenu(const rpg::ParticleEngine* PE) {
+  std::vector<rpg::hud::Widget*> options_widgets = {
+      new hud::Slider("Simulation Timescale", "Simulation Timescale",
+                      &rpg::simulation::time_scale)};
+
+  std::vector<rpg::hud::Widget*> fps_widgets{
+      new hud::FPSCounter("FrameCounter"),
+      new hud::Label("Particle Counter", std::bind(GetParticleCount, PE))};
+
+  HudManager::CreateWindow("Options");
+
+  for (const auto& widget : options_widgets)
+    HudManager::AddWidget("Options", widget);
+
+  HudManager::CreateWindow("Performance Metrics", 0, 640, true);
+  for (const auto& widget : fps_widgets)
+    HudManager::AddWidget("Performance Metrics", widget);
+}
+}  // namespace rpg::menus

--- a/src/menus/settings.cpp
+++ b/src/menus/settings.cpp
@@ -23,18 +23,25 @@ std::string GetParticleCount(ParticleEngine* ps) {
 void InitParticleMenu(rpg::ParticleEngine* PE) {
   vector<Widget*> options_widgets = {
       new Label("Simulation", "Simulation"),
-      new Slider("Simulation Timescale", &rpg::simulation::time_scale, 0.0f,
-                 2.0f),
-
+      new Slider("Simulation Speed", &rpg::simulation::time_scale, 0.0f, 2.0f),
       new Label("Particle System", "Particle System"),
-      new Slider("Number of Particles", &PE->max_particles, 1, 100000),
-      new Slider("Particle Lifetime", &PE->particle_lifetime, 0.1, 10),
-      new Slider("Horizontal Angle", &PE->angle, 0, 85),
-      new Slider("Magnitude", &PE->magnitude, 1, 20),
-      new Slider("Fire Rate", &PE->fire_rate, 0.001, 0.1),
-
+      new Slider(
+          "Number of Particles", &PE->max_particles, 1, 100000,
+          "Maximum number of particles that can be alive at any time. Once "
+          "this cap is reached, no more particles will be created."),
+      new Slider("Particle Lifetime", &PE->particle_lifetime, 0.1, 10,
+                 "The time in seconds before a particle is destroyed."),
+      new Slider("Vertical Angle", &PE->angle, 0, 85,
+                 "Angle between +Y and the ground to fire particles in."),
+      new Slider(
+          "Magnitude", &PE->magnitude, 1, 20,
+          "The magnitude of a particle's initial velocity upon creation"),
+      new Slider("Fire Rate", &PE->fire_rate, 0.001, 0.1,
+                 "The minimum time between creation of each particle."),
       new Label("Particle Physics", "Particle Physics"),
-      new Slider("CoR", &PE->coeff_of_restitution, 0, 1)};
+      new Slider("CoR", &PE->coeff_of_restitution, 0, 1,
+                 "Coefficent of Restitution. Determines how much energy is "
+                 "lost by a particle upon bouncing. ")};
 
   vector<Widget*> fps_widgets{
       new FPSCounter("FrameCounter"),

--- a/src/menus/settings.cpp
+++ b/src/menus/settings.cpp
@@ -10,6 +10,9 @@
 #include <window/hud/button.h>
 #include <window/hud/fps_counter.h>
 
+using namespace rpg::hud;
+using std::string;
+using std::vector;
 namespace rpg::menus {
 
 std::string GetParticleCount(const ParticleEngine* ps) {
@@ -17,13 +20,13 @@ std::string GetParticleCount(const ParticleEngine* ps) {
 }
 
 void InitParticleMenu(const rpg::ParticleEngine* PE) {
-  std::vector<rpg::hud::Widget*> options_widgets = {
-      new hud::Slider("Simulation Timescale", "Simulation Timescale",
-                      &rpg::simulation::time_scale)};
+  vector<Widget*> options_widgets = {new Slider("Simulation Timescale",
+                                                "Simulation Timescale",
+                                                &rpg::simulation::time_scale)};
 
-  std::vector<rpg::hud::Widget*> fps_widgets{
-      new hud::FPSCounter("FrameCounter"),
-      new hud::Label("Particle Counter", std::bind(GetParticleCount, PE))};
+  vector<Widget*> fps_widgets{
+      new FPSCounter("FrameCounter"),
+      new Label("Particle Counter", std::bind(GetParticleCount, PE))};
 
   HudManager::CreateWindow("Options");
 

--- a/src/menus/settings.h
+++ b/src/menus/settings.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <entities/particle_system.h>
+namespace rpg::menus {
+
+/*! \brief Create and add the particle menu to the hudmanager*/
+void InitParticleMenu(const rpg::ParticleEngine* PE);
+
+}  // namespace rpg::menus

--- a/src/menus/settings.h
+++ b/src/menus/settings.h
@@ -4,6 +4,6 @@
 namespace rpg::menus {
 
 /*! \brief Create and add the particle menu to the hudmanager*/
-void InitParticleMenu(const rpg::ParticleEngine* PE);
+void InitParticleMenu(rpg::ParticleEngine* PE);
 
 }  // namespace rpg::menus

--- a/src/physics/kinematics.h
+++ b/src/physics/kinematics.h
@@ -31,8 +31,8 @@ inline auto kinematic_energy(const Vector3D auto& velocity, Numeric auto mass) {
   return kinematic_energy(velocity_magnitude, mass);
 }
 
-template <Numeric N = double>
-inline auto velocity_from_kinematic_energy(N kinematic_energy, N mass) {
+inline auto velocity_from_kinematic_energy(Numeric auto kinematic_energy,
+                                           Numeric auto mass) {
   return sqrt(2 * kinematic_energy / mass);
 }
 

--- a/src/physics/rigid_body.h
+++ b/src/physics/rigid_body.h
@@ -43,25 +43,25 @@ inline void bounce_basic(RigidBody auto& body,
   const double distance_underground = abs(collision_pos - get(body.pos, 1));
   const double time_since_collision = distance_underground / y_vel;
 
+  // Rewind the particle to the time just before the point of collision
+  physics::apply_velocity(body, -time_since_collision);
+
   // Calculate how much energy was lost with the bounce
-  const Numeric auto energy = kinematic_energy(body, mass);
-  const auto energy_loss = calculate_energy_loss(e);
-  const auto energy_after_bounce = energy_loss * energy;
+  const double energy = kinematic_energy(y_vel, mass);
+  const double energy_loss = calculate_energy_loss(e);
+  const double energy_after_bounce = energy - (energy_loss * energy);
 
   // Update the velocity of the body based on the new energy
   const auto velocity_after_bounce =
       velocity_from_kinematic_energy(energy_after_bounce, mass);
-  set_magnitude(body.velocity, velocity_after_bounce);
+  set(body.velocity, 1, velocity_after_bounce);
 
   // Invert the y-direction of the velocity since it has bounced then
-  // move the particle since it's bounce, and set the position to the
-  // point of collision
-  set(body.velocity, 1, -get(body.velocity, 1));
-  set(body.pos, 1, collision_pos);
+  // move the particle since it's bounce
+  // set(body.velocity, 1, -get(body.velocity, 1));
 
-  // replay the motion of the object since the time of impact
-  if (time_since_collision > 0) {
-    physics::apply_velocity(body, time_since_collision);
-  }
-}
+  // replay the motion of the object since the time of impact with the new
+  // velocity
+  physics::apply_velocity(body, time_since_collision);
+}  // namespace rpg::physics
 }  // namespace rpg::physics

--- a/src/physics/rigid_body.h
+++ b/src/physics/rigid_body.h
@@ -29,7 +29,8 @@ inline auto kinematic_energy(const RigidBody auto& body, Numeric auto mass) {
 
 inline void bounce_basic(RigidBody auto& body,
                          Numeric auto mass = 5.0,
-                         Numeric auto e = 0) {
+                         Numeric auto e = 0,
+                         Numeric auto collision_pos = 0.0) {
   // Do nothing if the particle has no vertical momentum
   const auto y_vel = abs(get(body.velocity, 1));
   if (y_vel < 0.001) {
@@ -39,15 +40,28 @@ inline void bounce_basic(RigidBody auto& body,
     return;
   }
 
-  const Numeric auto energy = kinematic_energy(body, mass);
+  const double distance_underground = abs(collision_pos - get(body.pos, 1));
+  const double time_since_collision = distance_underground / y_vel;
 
+  // Calculate how much energy was lost with the bounce
+  const Numeric auto energy = kinematic_energy(body, mass);
   const auto energy_loss = calculate_energy_loss(e);
   const auto energy_after_bounce = energy_loss * energy;
 
+  // Update the velocity of the body based on the new energy
   const auto velocity_after_bounce =
       velocity_from_kinematic_energy(energy_after_bounce, mass);
   set_magnitude(body.velocity, velocity_after_bounce);
+
+  // Invert the y-direction of the velocity since it has bounced then
+  // move the particle since it's bounce, and set the position to the
+  // point of collision
   set(body.velocity, 1, -get(body.velocity, 1));
-  set(body.pos, 1, 0);
+  set(body.pos, 1, collision_pos);
+
+  // replay the motion of the object since the time of impact
+  if (time_since_collision > 0) {
+    physics::apply_velocity(body, time_since_collision);
+  }
 }
 }  // namespace rpg::physics

--- a/src/physics/rigid_body.h
+++ b/src/physics/rigid_body.h
@@ -52,7 +52,7 @@ inline void bounce_basic(RigidBody auto& body,
   const double energy_after_bounce = energy - (energy_loss * energy);
 
   // Update the velocity of the body based on the new energy
-  const auto velocity_after_bounce =
+  const double velocity_after_bounce =
       velocity_from_kinematic_energy(energy_after_bounce, mass);
   set(body.velocity, 1, velocity_after_bounce);
 

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -1,21 +1,18 @@
 #include <scene.h>
+
 #include <rendering\renderer.h>
 #include <rendering\preloaded_shaders.h>
+
 #include <entities/entity.h>
 #include <entities/entity_registry.h>
 #include <entities/particle_simulation.h>
 
-#include <window/hud_manager.h>
-#include <window/hud/label.h>
-#include <window/hud/button.h>
-#include <window/hud/widget.h>
-#include <window/hud/slider.h>
-#include <window/hud/combo.h>
-#include <window/hud/fps_counter.h>
-
 #include <system/control_manager.h>
 #include <system\kbm_movement.h>
+
 #include <utils.h>
+
+#include <menus/settings.h>
 
 #include <cassert>
 #include <exception>
@@ -23,26 +20,6 @@
 #include <string>
 
 namespace rpg {
-
-std::string GetParticleCount(const ParticleEngine* ps) {
-  return "Particle Count: " + std::to_string(ps->NumVertices());
-}
-
-void SetupHud(const ParticleEngine* PE) {
-  hud::Slider* time_slider =
-      new hud::Slider("Simulation Timescale", "Simulation Timescale",
-                      &rpg::simulation::time_scale);
-  hud::FPSCounter* fps = new hud::FPSCounter("FrameCounter");
-  hud::Label* particle_count =
-      new hud::Label("Particle Counter", std::bind(GetParticleCount, PE));
-
-  HudManager::CreateWindow("Options");
-  HudManager::AddWidget("Options", time_slider);
-
-  HudManager::CreateWindow("Framerate", 0, 640, true);
-  HudManager::AddWidget("Framerate", fps);
-  HudManager::AddWidget("Framerate", particle_count);
-}
 
 void ScreenResizeCallback(float x, float y) {
   rpg::rendering::Renderer::UpdateScreenXY(x, y);
@@ -68,7 +45,7 @@ void Scene::Start() {
   this->PI->SetID(Registry::GetNextID());
 
   // Add hud widgets
-  SetupHud(&(*PI));
+  rpg::menus::InitParticleMenu(&(*PI));
 
   // Initiate draw loop
   printf("Beginning Draw Loop. \n");

--- a/src/window/hud/slider.cpp
+++ b/src/window/hud/slider.cpp
@@ -3,15 +3,36 @@
 #include <imgui.h>
 
 namespace rpg::hud {
+
+Slider::Slider(const std::string& name, int* var, float min, float max)
+    : Label(name, name), int_ptr(var), max(max), min(min) {
+  this->type = SliderType::INT;
+}
+
+Slider::Slider(const std::string& name, float* var, float min, float max)
+    : Label(name, name), float_ptr(var), max(max), min(min) {
+  this->type = SliderType::FLOAT;
+}
+
 Slider::Slider(const std::string& name,
                const std::string& label,
                float* var,
                float min,
                float max)
-    : Label(name, label), var(var), min(min), max(max) {}
+    : Label(name, label), float_ptr(var), min(min), max(max) {
+  this->type = SliderType::FLOAT;
+}
 
 void Slider::Draw() {
-  ImGui::SliderFloat(this->text.c_str(), this->var, this->min, this->max,
-                     "%.3f", 1);
+  switch (this->type) {
+    case SliderType::FLOAT:
+      ImGui::SliderFloat(this->text.c_str(), this->float_ptr, this->min,
+                         this->max, "%.3f", 1);
+      break;
+    case SliderType::INT:
+      ImGui::SliderInt(this->text.c_str(), this->int_ptr, this->min, this->max,
+                       "%d", 1);
+      break;
+  }
 }
 }  // namespace rpg::hud

--- a/src/window/hud/slider.cpp
+++ b/src/window/hud/slider.cpp
@@ -4,23 +4,44 @@
 
 namespace rpg::hud {
 
-Slider::Slider(const std::string& name, int* var, float min, float max)
-    : Label(name, name), int_ptr(var), max(max), min(min) {
-  this->type = SliderType::INT;
+Slider::Slider(const std::string& name,
+               int* var,
+               float min,
+               float max,
+               const std::string& help_text)
+    : Label(name, name),
+      int_ptr(var),
+      max(max),
+      min(min),
+      type(SliderType::INT) {
+  this->SetHelpMarker(help_text);
 }
 
-Slider::Slider(const std::string& name, float* var, float min, float max)
-    : Label(name, name), float_ptr(var), max(max), min(min) {
-  this->type = SliderType::FLOAT;
+Slider::Slider(const std::string& name,
+               float* var,
+               float min,
+               float max,
+               const std::string& help_text)
+    : Label(name, name),
+      float_ptr(var),
+      max(max),
+      min(min),
+      type(SliderType::FLOAT) {
+  this->SetHelpMarker(help_text);
 }
 
 Slider::Slider(const std::string& name,
                const std::string& label,
                float* var,
                float min,
-               float max)
-    : Label(name, label), float_ptr(var), min(min), max(max) {
-  this->type = SliderType::FLOAT;
+               float max,
+               const std::string& help_text)
+    : Label(name, label),
+      float_ptr(var),
+      min(min),
+      max(max),
+      type(SliderType::FLOAT) {
+  this->SetHelpMarker(help_text);
 }
 
 void Slider::Draw() {

--- a/src/window/hud/slider.h
+++ b/src/window/hud/slider.h
@@ -15,18 +15,24 @@ class Slider : public Label {
   float max, min;
 
  public:
-  Slider(const std::string& name, int* var, float min = 0.0f, float max = 1.0f);
+  Slider(const std::string& name,
+         int* var,
+         float min = 0.0f,
+         float max = 1.0f,
+         const std::string& help_text = "");
 
   Slider(const std::string& name,
          float* var,
          float min = 0.0f,
-         float max = 1.0f);
+         float max = 1.0f,
+         const std::string& help_text = "");
 
   Slider(const std::string& name,
          const std::string& label,
          float* var,
          float min = 0.0f,
-         float max = 1.0f);
+         float max = 1.0f,
+         const std::string& help_text = "");
 
   void Draw();
 

--- a/src/window/hud/slider.h
+++ b/src/window/hud/slider.h
@@ -5,14 +5,23 @@
 
 #include <string>
 #include <functional>
-
 namespace rpg::hud {
 class Slider : public Label {
-  float* var;
-  float min, max;
-  // std::function<void(float)> callback;
+  enum class SliderType { INT, FLOAT };
+
+  int* int_ptr;
+  float* float_ptr;
+  SliderType type;
+  float max, min;
 
  public:
+  Slider(const std::string& name, int* var, float min = 0.0f, float max = 1.0f);
+
+  Slider(const std::string& name,
+         float* var,
+         float min = 0.0f,
+         float max = 1.0f);
+
   Slider(const std::string& name,
          const std::string& label,
          float* var,
@@ -22,5 +31,5 @@ class Slider : public Label {
   void Draw();
 
   ~Slider(){};
-};
+};  // namespace rpg::hud
 }  // namespace rpg::hud


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/8203854/97889845-d7089e00-1cfa-11eb-8f19-a3f7abb5eaef.png)


Add some more basic simulation controls, improve physics accuracy/update logic,  and lay the groundwork for future systems. 

## Changes:
- Sliders now support integers, and help text in their constructors. 
- Relocate existing settings menu code in a new namespace dedicated to menus.
- Add additional options for simulation control shown in the above picture.
- Move higher level particle simulation code into the particle system itself. 
- Implement more accurate in bounce calculations. Now only the y-component is affected instead of the entire velocity vector itself, resulting in a more realistic trajectory after bounce.
- Upon bouncing,  the particle's position will be set to the point of impact and have the time between the update and the impact replayed with its new velocity. Previously this would result in the particle retaining it's previous velocity until the next update unless it bounced at exactly the same time it collided with the ground. 
- Limit maximum time between updates. If an update occurs that is longer than 0.016 ms, then it will broken into 0.016 steps to ensure consistency.
- Remove dynamic coloring for now. This will be re-implemented in a future pull. 