### PR TITLE
Optimization Pass 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,32 @@
 cmake_minimum_required (VERSION 3.8)
 project ("RandomParticleEngine")
 
+
+# Set compiler commands
+set(GENERAL_COMPILER_OPTIONS
+)
+
+set(RELEASE_OPTIONS
+  -Ofast
+  -flto
+  -fuse-linker-plugin
+  -pipe
+  -fomit-frame-pointer
+)
+
+set(RELEASE_DEBUG_OPTIONS
+  -Ofast
+  -g
+  -Wall
+)
+
+set(DEBUG_OPTIONS
+  -Wall
+  -Wextra
+  -Og
+  -g
+)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 if(CMAKE_EXPORT_COMPILE_COMMANDS)
     set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
@@ -14,6 +40,7 @@ endif()
 
 # headers
 set(CXX_STANDARD 20)
+
 
 include(FetchContent)
 
@@ -168,8 +195,22 @@ set_property(
   PROPERTY CXX_STANDARD 20
 )
 
+
+
+message([status] ${CMAKE_BUILD_TYPE})
+if(${CMAKE_BUILD_TYPE} STREQUAL "Release")
+  list(APPEND GENERAL_COMPILER_OPTIONS ${RELEASE_OPTIONS})
+  message("USING RELEASE OPTIMIZATIONS")
+elseif(${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
+  list(APPEND GENERAL_COMPILER_OPTIONS ${RELEASE_DEBUG_OPTIONS})
+  message("USING DEBUG-RELEASE OPTIMIZATIONS")
+else()
+  list(APPEND GENERAL_COMPILER_OPTIONS ${DEBUG_OPTIONS})
+  message("USING DEBUG")
+endif()
+
 target_compile_options(
-  RandomParticleEngine PRIVATE -Wall -Wextra -g
+  RandomParticleEngine PRIVATE ${GENERAL_COMPILER_OPTIONS}
 )
 
 add_custom_command(

--- a/src/entities/particle.cpp
+++ b/src/entities/particle.cpp
@@ -1,14 +1,2 @@
 
 #include <entities\particle.h>
-
-namespace rpg {
-
-Particle::Particle(glm::vec3 pos, glm::vec3 color)
-    : pos(pos), color(color), velocity(0, 0, 0), lifetime(-1.0f) {}
-
-Particle::Particle()
-    : pos(glm::vec3(0, 0, 0)),
-      color(glm::vec3(0, 0, 0)),
-      velocity(glm::vec3(0, 0, 0)),
-      lifetime(-1.0f) {}
-}  // namespace rpg

--- a/src/entities/particle.cpp
+++ b/src/entities/particle.cpp
@@ -7,6 +7,6 @@ Particle::Particle(glm::vec3 pos, glm::vec3 color) {
   this->pos = pos;
   this->color = color;
   this->velocity = glm::vec3{0, 0, 0};
-  this->lifetime = 0.0f;
+  this->lifetime = -1.0f;
 }
 }  // namespace rpg

--- a/src/entities/particle.cpp
+++ b/src/entities/particle.cpp
@@ -7,6 +7,6 @@ Particle::Particle(glm::vec3 pos, glm::vec3 color) {
   this->pos = pos;
   this->color = color;
   this->velocity = glm::vec3{0, 0, 0};
-  this->lifetime = 10.0f;
+  this->lifetime = 0.0f;
 }
 }  // namespace rpg

--- a/src/entities/particle.cpp
+++ b/src/entities/particle.cpp
@@ -3,10 +3,12 @@
 
 namespace rpg {
 
-Particle::Particle(glm::vec3 pos, glm::vec3 color) {
-  this->pos = pos;
-  this->color = color;
-  this->velocity = glm::vec3{0, 0, 0};
-  this->lifetime = -1.0f;
-}
+Particle::Particle(glm::vec3 pos, glm::vec3 color)
+    : pos(pos), color(color), velocity(0, 0, 0), lifetime(-1.0f) {}
+
+Particle::Particle()
+    : pos(glm::vec3(0, 0, 0)),
+      color(glm::vec3(0, 0, 0)),
+      velocity(glm::vec3(0, 0, 0)),
+      lifetime(-1.0f) {}
 }  // namespace rpg

--- a/src/entities/particle.h
+++ b/src/entities/particle.h
@@ -3,7 +3,7 @@
 namespace rpg {
 
 struct Particle {
-  using Vector3 = std::array<float, 3>;
+  using Vector3 = std::array<double, 3>;
   float lifetime;
   Vector3 pos;
   Vector3 color;

--- a/src/entities/particle.h
+++ b/src/entities/particle.h
@@ -8,6 +8,7 @@ struct Particle {
   glm::vec3 color = glm::vec3(0, 0, 0);
   float lifetime = -1.0f;
 
+  Particle();
   Particle(glm::vec3 pos, glm::vec3 color);
 };
 }  // namespace rpg

--- a/src/entities/particle.h
+++ b/src/entities/particle.h
@@ -1,14 +1,31 @@
 #pragma once
-#include <glm/glm.hpp>
-
+#include <array>
 namespace rpg {
-struct Particle {
-  float lifetime = -1.0f;
-  glm::vec3 pos = glm::vec3(0, 0, 0);
-  glm::vec3 color = glm::vec3(0, 0, 0);
-  glm::vec3 velocity = glm::vec3(0, 0, 0);
 
-  Particle();
-  Particle(glm::vec3 pos, glm::vec3 color);
+struct Particle {
+  using Vector3 = std::array<float, 3>;
+  float lifetime;
+  Vector3 pos;
+  Vector3 color;
+  Vector3 velocity;
+
+  inline Particle()
+      : lifetime(-1.0f),
+        pos(Vector3{0, 0, 0}),
+        color(Vector3{0, 0, 0}),
+        velocity(Vector3{0, 0, 0}){};
+
+  template <typename Vec>
+  inline void set_color(const Vec& new_color) {
+    color[0] = new_color[0];
+    color[1] = new_color[1];
+    color[2] = new_color[2];
+  }
+  template <typename Vec>
+  inline void set_velocity(const Vec& new_velocity) {
+    velocity[0] = new_velocity[0];
+    velocity[1] = new_velocity[1];
+    velocity[2] = new_velocity[2];
+  }
 };
 }  // namespace rpg

--- a/src/entities/particle.h
+++ b/src/entities/particle.h
@@ -3,10 +3,10 @@
 
 namespace rpg {
 struct Particle {
-  glm::vec3 pos;
-  glm::vec3 velocity;
-  glm::vec3 color;
-  float lifetime;
+  glm::vec3 pos = glm::vec3(0, 0, 0);
+  glm::vec3 velocity = glm::vec3(0, 0, 0);
+  glm::vec3 color = glm::vec3(0, 0, 0);
+  float lifetime = -1.0f;
 
   Particle(glm::vec3 pos, glm::vec3 color);
 };

--- a/src/entities/particle.h
+++ b/src/entities/particle.h
@@ -3,10 +3,10 @@
 
 namespace rpg {
 struct Particle {
-  glm::vec3 pos = glm::vec3(0, 0, 0);
-  glm::vec3 velocity = glm::vec3(0, 0, 0);
-  glm::vec3 color = glm::vec3(0, 0, 0);
   float lifetime = -1.0f;
+  glm::vec3 pos = glm::vec3(0, 0, 0);
+  glm::vec3 color = glm::vec3(0, 0, 0);
+  glm::vec3 velocity = glm::vec3(0, 0, 0);
 
   Particle();
   Particle(glm::vec3 pos, glm::vec3 color);

--- a/src/entities/particle.h
+++ b/src/entities/particle.h
@@ -3,7 +3,7 @@
 namespace rpg {
 
 struct Particle {
-  using Vector3 = std::array<double, 3>;
+  using Vector3 = std::array<float, 3>;
   float lifetime;
   Vector3 pos;
   Vector3 color;

--- a/src/entities/particle_color_algs.cpp
+++ b/src/entities/particle_color_algs.cpp
@@ -8,7 +8,7 @@
 
 namespace rpg::simulation {
 void rainbow_by_lifetime(Particle& P, float max_lifetime) {
-  P.color = rainbow_by_param(0, max_lifetime, P.lifetime);
+  P.set_color(rainbow_by_param(0, max_lifetime, P.lifetime));
 }
 
 glm::vec3 rainbow_by_param(float min, float max, float val) {

--- a/src/entities/particle_color_algs.cpp
+++ b/src/entities/particle_color_algs.cpp
@@ -11,27 +11,27 @@ void rainbow_by_lifetime(Particle& P, float max_lifetime) {
   P.set_color(rainbow_by_param(0, max_lifetime, P.lifetime));
 }
 
-glm::vec3 rainbow_by_param(float min, float max, float val) {
-  const float violet_cutoff = 0.3;
+glm::vec3 rainbow_by_param(double min, double max, double val) {
+  const double violet_cutoff = 0.3;
 
   // Add red_cutoff to the hue to ensure it isn't in red if it's near zero
-  float hue = rpg::math::inverse_lerp(min, max, val);
+  double hue = rpg::math::inverse_lerp(min, max, val);
 
-  const float capped_hue = 1.0 - std::lerp(violet_cutoff, 1.0, hue);
-  const float clamped_hue = std::clamp(capped_hue, 0.0f, 1.0f);
+  const double capped_hue = 1.0 - std::lerp(violet_cutoff, 1.0, hue);
+  const double clamped_hue = std::clamp(capped_hue, 0.0, 1.0);
 
-  glm::vec3 return_color = glm::vec3{clamped_hue, 1.0f, 1.0f};
+  glm::vec3 return_color = glm::vec3{clamped_hue, 1.0, 1.0};
   rpg::math::color::hsv_to_rgb(return_color);
 
   return return_color;
 }
 
-glm::vec3 lerp_by_param(float min,
-                        float max,
-                        float val,
+glm::vec3 lerp_by_param(double min,
+                        double max,
+                        double val,
                         const glm::vec3& color1,
                         const glm::vec3& color2) {
-  const float dist = rpg::math::inverse_lerp(min, max, val);
+  const double dist = rpg::math::inverse_lerp(min, max, val);
 
   return glm::mix(color2, color1, dist);
 }

--- a/src/entities/particle_color_algs.cpp
+++ b/src/entities/particle_color_algs.cpp
@@ -11,27 +11,27 @@ void rainbow_by_lifetime(Particle& P, float max_lifetime) {
   P.set_color(rainbow_by_param(0, max_lifetime, P.lifetime));
 }
 
-glm::vec3 rainbow_by_param(double min, double max, double val) {
-  const double violet_cutoff = 0.3;
+glm::vec3 rainbow_by_param(float min, float max, float val) {
+  const float violet_cutoff = 0.3;
 
   // Add red_cutoff to the hue to ensure it isn't in red if it's near zero
-  double hue = rpg::math::inverse_lerp(min, max, val);
+  float hue = rpg::math::inverse_lerp(min, max, val);
 
-  const double capped_hue = 1.0 - std::lerp(violet_cutoff, 1.0, hue);
-  const double clamped_hue = std::clamp(capped_hue, 0.0, 1.0);
+  const float capped_hue = 1.0 - std::lerp(violet_cutoff, 1.0f, hue);
+  const float clamped_hue = std::clamp(capped_hue, 0.0f, 1.0f);
 
-  glm::vec3 return_color = glm::vec3{clamped_hue, 1.0, 1.0};
+  glm::vec3 return_color = glm::vec3{clamped_hue, 1.0f, 1.0f};
   rpg::math::color::hsv_to_rgb(return_color);
 
   return return_color;
 }
 
-glm::vec3 lerp_by_param(double min,
-                        double max,
-                        double val,
+glm::vec3 lerp_by_param(float min,
+                        float max,
+                        float val,
                         const glm::vec3& color1,
                         const glm::vec3& color2) {
-  const double dist = rpg::math::inverse_lerp(min, max, val);
+  const float dist = rpg::math::inverse_lerp(min, max, val);
 
   return glm::mix(color2, color1, dist);
 }

--- a/src/entities/particle_color_algs.cpp
+++ b/src/entities/particle_color_algs.cpp
@@ -11,16 +11,16 @@ void rainbow_by_lifetime(Particle& P, float max_lifetime) {
   P.set_color(rainbow_by_param(0, max_lifetime, P.lifetime));
 }
 
-glm::vec3 rainbow_by_param(float min, float max, float val) {
-  const float violet_cutoff = 0.3;
+std::array<float, 3> rainbow_by_param(float min, float max, float val) {
+  const float violet_cutoff = 0.3f;
 
   // Add red_cutoff to the hue to ensure it isn't in red if it's near zero
   float hue = rpg::math::inverse_lerp(min, max, val);
 
-  const float capped_hue = 1.0 - std::lerp(violet_cutoff, 1.0f, hue);
+  const float capped_hue = 1.0f - std::lerp(violet_cutoff, 1.0f, hue);
   const float clamped_hue = std::clamp(capped_hue, 0.0f, 1.0f);
 
-  glm::vec3 return_color = glm::vec3{clamped_hue, 1.0f, 1.0f};
+  std::array<float, 3> return_color{clamped_hue, 1.0f, 1.0f};
   rpg::math::color::hsv_to_rgb(return_color);
 
   return return_color;

--- a/src/entities/particle_color_algs.h
+++ b/src/entities/particle_color_algs.h
@@ -1,4 +1,7 @@
+#pragma once
+#include <glm/glm.hpp>
 #include <entities/particle.h>
+
 namespace rpg::simulation {
 void rainbow_by_lifetime(Particle& P, float max_lifetime);
 

--- a/src/entities/particle_color_algs.h
+++ b/src/entities/particle_color_algs.h
@@ -7,11 +7,11 @@ void rainbow_by_lifetime(Particle& P, float max_lifetime);
 
 /*! \brief Determine how far val is between min/max then use that as a hue value
  * on a HSV scale.*/
-glm::vec3 rainbow_by_param(float min, float max, float val);
+glm::vec3 rainbow_by_param(double min, double max, double val);
 
-glm::vec3 lerp_by_param(float min,
-                        float max,
-                        float val,
+glm::vec3 lerp_by_param(double min,
+                        double max,
+                        double val,
                         const glm::vec3& color1,
                         const glm::vec3& color2);
 }  // namespace rpg::simulation

--- a/src/entities/particle_color_algs.h
+++ b/src/entities/particle_color_algs.h
@@ -7,7 +7,7 @@ void rainbow_by_lifetime(Particle& P, float max_lifetime);
 
 /*! \brief Determine how far val is between min/max then use that as a hue value
  * on a HSV scale.*/
-glm::vec3 rainbow_by_param(float min, float max, float val);
+std::array<float, 3> rainbow_by_param(float min, float max, float val);
 
 glm::vec3 lerp_by_param(float min,
                         float max,

--- a/src/entities/particle_color_algs.h
+++ b/src/entities/particle_color_algs.h
@@ -7,11 +7,11 @@ void rainbow_by_lifetime(Particle& P, float max_lifetime);
 
 /*! \brief Determine how far val is between min/max then use that as a hue value
  * on a HSV scale.*/
-glm::vec3 rainbow_by_param(double min, double max, double val);
+glm::vec3 rainbow_by_param(float min, float max, float val);
 
-glm::vec3 lerp_by_param(double min,
-                        double max,
-                        double val,
+glm::vec3 lerp_by_param(float min,
+                        float max,
+                        float val,
                         const glm::vec3& color1,
                         const glm::vec3& color2);
 }  // namespace rpg::simulation

--- a/src/entities/particle_simulation.cpp
+++ b/src/entities/particle_simulation.cpp
@@ -51,14 +51,16 @@ inline float get_rand_nolimits() {
 
 /*! \brief Move particle based on it's velocity */
 void update_particle_position(Particle& p, float time) {
-  physics::update_position_with_gravity(p.pos, p.velocity, time);
+  // physics::update_position_with_gravity(p.pos, p.velocity, time);
 }
 
-void simple_ground_bounce(Particle& p,
-                          float ground_height,
-                          float e,
-                          float time_since_last_update) {
-  physics::bounce_basic(p, 0.5, e, ground_height, time_since_last_update);
+void run_physics_simulation(Particle& p,
+                            bool enable_bounce,
+                            float ground_height,
+                            float e,
+                            float time_since_last_update) {
+  physics::full_simulation_step(p, enable_bounce, 0.5f, e, 0.0f,
+                                time_since_last_update);
 }
 
 const glm::vec3 origin(0, 0, 0);

--- a/src/entities/particle_simulation.cpp
+++ b/src/entities/particle_simulation.cpp
@@ -50,17 +50,15 @@ inline float get_rand_nolimits() {
 }
 
 /*! \brief Move particle based on it's velocity */
-void update_particle_position(Particle& p, double time) {
-  physics::update_position_with_gravity(p.pos, p.velocity,
-                                        static_cast<float>(time));
+void update_particle_position(Particle& p, float time) {
+  physics::update_position_with_gravity(p.pos, p.velocity, time);
 }
 
 void simple_ground_bounce(Particle& p,
                           float ground_height,
                           float e,
-                          double time_since_last_update) {
-  physics::bounce_basic(p, 0.5, e, ground_height,
-                        static_cast<float>(time_since_last_update));
+                          float time_since_last_update) {
+  physics::bounce_basic(p, 0.5, e, ground_height, time_since_last_update);
 }
 
 const glm::vec3 origin(0, 0, 0);

--- a/src/entities/particle_simulation.cpp
+++ b/src/entities/particle_simulation.cpp
@@ -59,8 +59,7 @@ bool simple_ground_bounce(Particle& p,
                           float e,
                           double time_since_last_update) {
   if (p.pos.y <= ground_height && p.velocity.y < 0) {
-    physics::bounce_basic(p, 0.5, e, static_cast<double>(ground_height),
-                          time_since_last_update);
+    physics::bounce_basic(p, 0.5, e, ground_height, time_since_last_update);
     return true;
   }
   return false;
@@ -82,7 +81,6 @@ Particle fire_particle(float magnitude,
 
   Particle out_particle(origin, white);
   out_particle.velocity = (dir * magnitude);
-  out_particle.color = {0, 0.25, 1};
   out_particle.lifetime = lifetime;
   return out_particle;
 }

--- a/src/entities/particle_simulation.cpp
+++ b/src/entities/particle_simulation.cpp
@@ -54,15 +54,13 @@ void update_particle_position(Particle& p, double time) {
   physics::update_position_with_gravity(p.pos, p.velocity, time);
 }
 
-bool simple_ground_bounce(Particle& p,
+void simple_ground_bounce(Particle& p,
                           float ground_height,
                           float e,
                           double time_since_last_update) {
   if (p.pos.y <= ground_height && p.velocity.y < 0) {
     physics::bounce_basic(p, 0.5, e, ground_height, time_since_last_update);
-    return true;
   }
-  return false;
 }
 
 const glm::vec3 origin(0, 0, 0);
@@ -75,7 +73,7 @@ Particle fire_particle(float magnitude,
   const double horizontal_angle = get_rand(0, max_horizontal_angle);
   static const float rotation = math::to_radians<int, float>(-90);
 
-  auto dir = math::spherical_to_cartesian(glm::vec3(
+  glm::vec3 dir = math::spherical_to_cartesian(glm::vec3(
       1, math::to_radians(horizontal_angle), math::to_radians(vertical_angle)));
   dir = glm::rotateX(dir, rotation);
 

--- a/src/entities/particle_simulation.cpp
+++ b/src/entities/particle_simulation.cpp
@@ -58,7 +58,7 @@ void simple_ground_bounce(Particle& p,
                           float ground_height,
                           float e,
                           double time_since_last_update) {
-  if (p.pos.y <= ground_height && p.velocity.y < 0) {
+  if (p.pos[1] <= ground_height && p.velocity[1] < 0) {
     physics::bounce_basic(p, 0.5, e, ground_height, time_since_last_update);
   }
 }
@@ -77,8 +77,8 @@ Particle fire_particle(float magnitude,
       1, math::to_radians(horizontal_angle), math::to_radians(vertical_angle)));
   dir = glm::rotateX(dir, rotation);
 
-  Particle out_particle(origin, white);
-  out_particle.velocity = (dir * magnitude);
+  Particle out_particle;
+  out_particle.set_velocity(dir * magnitude);
   out_particle.lifetime = lifetime;
   return out_particle;
 }

--- a/src/entities/particle_simulation.cpp
+++ b/src/entities/particle_simulation.cpp
@@ -51,14 +51,16 @@ inline float get_rand_nolimits() {
 
 /*! \brief Move particle based on it's velocity */
 void update_particle_position(Particle& p, double time) {
-  physics::update_position_with_gravity(p.pos, p.velocity, time);
+  physics::update_position_with_gravity(p.pos, p.velocity,
+                                        static_cast<float>(time));
 }
 
 void simple_ground_bounce(Particle& p,
                           float ground_height,
                           float e,
                           double time_since_last_update) {
-  physics::bounce_basic(p, 0.5, e, ground_height, time_since_last_update);
+  physics::bounce_basic(p, 0.5, e, ground_height,
+                        static_cast<float>(time_since_last_update));
 }
 
 const glm::vec3 origin(0, 0, 0);

--- a/src/entities/particle_simulation.cpp
+++ b/src/entities/particle_simulation.cpp
@@ -58,9 +58,7 @@ void simple_ground_bounce(Particle& p,
                           float ground_height,
                           float e,
                           double time_since_last_update) {
-  if (p.pos[1] <= ground_height && p.velocity[1] < 0) {
-    physics::bounce_basic(p, 0.5, e, ground_height, time_since_last_update);
-  }
+  physics::bounce_basic(p, 0.5, e, ground_height, time_since_last_update);
 }
 
 const glm::vec3 origin(0, 0, 0);

--- a/src/entities/particle_simulation.h
+++ b/src/entities/particle_simulation.h
@@ -13,10 +13,11 @@ double get_time_since(double last_time);
 
 double get_time();
 
-void simple_ground_bounce(Particle& P,
-                          float ground_height,
-                          float e,
-                          float time);
+void run_physics_simulation(Particle& P,
+                            bool enable_bounce,
+                            float ground_height,
+                            float e,
+                            float time);
 
 Particle fire_particle(float magnitude,
                        float vertical_angle,

--- a/src/entities/particle_simulation.h
+++ b/src/entities/particle_simulation.h
@@ -13,7 +13,7 @@ double get_time_since(double last_time);
 
 double get_time();
 
-bool simple_ground_bounce(Particle& P,
+void simple_ground_bounce(Particle& P,
                           float ground_height,
                           float e,
                           double time);

--- a/src/entities/particle_simulation.h
+++ b/src/entities/particle_simulation.h
@@ -7,7 +7,7 @@ namespace rpg::simulation {
 
 extern float time_scale;
 
-void update_particle_position(Particle& P, double time);
+void update_particle_position(Particle& P, float time);
 
 double get_time_since(double last_time);
 
@@ -16,7 +16,7 @@ double get_time();
 void simple_ground_bounce(Particle& P,
                           float ground_height,
                           float e,
-                          double time);
+                          float time);
 
 Particle fire_particle(float magnitude,
                        float vertical_angle,

--- a/src/entities/particle_system.cpp
+++ b/src/entities/particle_system.cpp
@@ -89,10 +89,10 @@ inline float ParticleEngine::get_particle_value(const Particle& P) {
       return P.lifetime;
       break;
     case PARAMETER::VELOCITY:
-      return abs(P.velocity.y);
+      return abs(P.velocity[1]);
       break;
     case PARAMETER::DIST_FROM_GROUND:
-      return P.pos.y;
+      return P.pos[1];
       break;
   }
   return 0.0f;
@@ -105,9 +105,10 @@ inline void ParticleEngine::color_particle(Particle& P, float min, float max) {
   const float val = get_particle_value(P);
 
   if (color_mode == COLOR_MODE::RAINBOW)
-    P.color = simulation::rainbow_by_param(min, max, val);
+    P.set_color(simulation::rainbow_by_param(min, max, val));
   else if (color_mode == COLOR_MODE::GRADIENT)
-    P.color = simulation::lerp_by_param(min, max, val, start_color, end_color);
+    P.set_color(
+        simulation::lerp_by_param(min, max, val, start_color, end_color));
 }
 
 void ParticleEngine::color_particle(Particle& P) {
@@ -134,7 +135,7 @@ void ParticleEngine::emit_particle(int queued_shots) {
         this->magnitude.get_number(), this->vertical_angle.get_number(),
         this->particle_lifetime, this->horizontal_angle);
 
-    P.color = start_color;
+    P.set_color(start_color);
     update_particle(P, time);
     color_particle(P);
 
@@ -249,13 +250,13 @@ int ParticleEngine::NumParticles() const {
 
 inline void ParticleEngine::update_arrays(Particle& P) {
   const int offset = this->num_particles * 3;
-  color_storage[offset] = P.color.x;
-  color_storage[offset + 1] = P.color.y;
-  color_storage[offset + 2] = P.color.z;
+  color_storage[offset] = P.color[0];
+  color_storage[offset + 1] = P.color[1];
+  color_storage[offset + 2] = P.color[2];
 
-  position_storage[offset] = P.pos.x;
-  position_storage[offset + 1] = P.pos.y;
-  position_storage[offset + 2] = P.pos.z;
+  position_storage[offset] = P.pos[0];
+  position_storage[offset + 1] = P.pos[1];
+  position_storage[offset + 2] = P.pos[2];
   this->num_particles += 1;
 }
 

--- a/src/entities/particle_system.cpp
+++ b/src/entities/particle_system.cpp
@@ -25,11 +25,7 @@ inline bool is_dead_particle(const Particle& P) {
 
 inline void ParticleEngine::update_particle(Particle& P, float time) {
   P.lifetime -= time;
-  // simulation::apply_gravity(P, time);
-  simulation::update_particle_position(P, time);
-
-  if (bounce)
-    simulation::simple_ground_bounce(P, 0, coeff_of_restitution, time);
+  simulation::run_physics_simulation(P, bounce, 0, coeff_of_restitution, time);
 }
 
 int ParticleEngine::queued_shots(double time_since) {

--- a/src/entities/particle_system.cpp
+++ b/src/entities/particle_system.cpp
@@ -152,8 +152,8 @@ void ParticleEngine::create_new_particles(double time, int count) {
   const int particles_remaining = std::max(max_particles - num_particles, 0);
   const int particle_budget = std::min(std::min(num_shots, particles_remaining),
                                        max_particles_per_frame);
-
-  emit_particle(particle_budget);
+  if (particle_budget > 0)
+    emit_particle(particle_budget);
 }
 
 ParticleEngine::ParticleEngine()
@@ -201,20 +201,16 @@ void ParticleEngine::simulate_particles(double time) {
   const float min = min_max[0];
   const float max = min_max[1];
 
-  int count = 0;
-  if (num_particles > 0) {
-    num_particles = 0;
-    // iterate through each living particle and update it
-    for_each(currently_live_particles,
-             [this, time, &count, min, max](Particle& p) {
-               update_particle(p, time);
-               color_particle(p, min, max);
-               // if the particle is still alive add it to our storage arrays
-               if (is_live_particle(p))
-                 update_arrays(p);
-             });
-    num_particles++;
-  }
+  num_particles = 0;
+  // iterate through each living particle and update it
+  for_each(currently_live_particles, [this, time, min, max](Particle& p) {
+    update_particle(p, time);
+    color_particle(p, min, max);
+    // if the particle is still alive add it to our storage arrays
+    if (is_live_particle(p))
+      update_arrays(p);
+  });
+  num_particles++;
 
   // Create new particles based on firerate
   create_new_particles(time, num_particles);
@@ -227,11 +223,11 @@ void ParticleEngine::Update() {
 
   // If the time is within our update threshold, simulate particles, then
   // update our last_update time
-  if (time > (simulation::time_scale * update_threshold)) {
-    const double this_update = simulation::get_time();
-    simulate_particles(time);
-    last_update = this_update;
-  }
+  // if (time > (simulation::time_scale * update_threshold)) {
+  const double this_update = simulation::get_time();
+  simulate_particles(time);
+  last_update = this_update;
+  //}
 }
 
 const std::vector<float>& ParticleEngine::GetColorBuffer() {

--- a/src/entities/particle_system.cpp
+++ b/src/entities/particle_system.cpp
@@ -144,13 +144,14 @@ void ParticleEngine::emit_particle(int num_particles) {
 }
 
 void ParticleEngine::create_new_particles(double time) {
-  if (NumVertices() >= max_particles)
+  if (NumVertices() / 3 >= max_particles)
     return;
 
   const int num_shots = queued_shots(time);
 
   // Limit max number of particles by max_particles and shot time
-  const int remaining_vertices = std::max(max_particles - NumVertices(), 0);
+  const int remaining_vertices =
+      std::max(max_particles - static_cast<int>(particles.size()), 0);
   const int particle_budget = std::clamp(num_shots, 0, remaining_vertices);
 
   emit_particle(particle_budget);

--- a/src/entities/particle_system.cpp
+++ b/src/entities/particle_system.cpp
@@ -258,4 +258,8 @@ inline void ParticleEngine::update_arrays(Particle& P, int i) {
   position_storage[offset + 2] = P.pos.z;
 }
 
+int ParticleEngine::MaxVertices() const {
+  return max_particles * 3;
+}
+
 }  // namespace rpg

--- a/src/entities/particle_system.cpp
+++ b/src/entities/particle_system.cpp
@@ -48,20 +48,20 @@ int ParticleEngine::queued_shots(double time_since) {
   return shots;
 }
 
-inline float calculate_height(float magnitude, float angle) {
+inline double calculate_height(double magnitude, double angle) {
   return abs(magnitude * std::sin(std::numbers::pi * (90.0 - angle) / 180.0));
 }
 
 inline float find_apex(float magnitude, float angle) {
-  const float y_component = calculate_height(magnitude, angle);
+  const double y_component = calculate_height(magnitude, angle);
 
-  float apex_time = y_component / 9.8;
+  double apex_time = y_component / 9.8;
 
   return y_component * apex_time + (-9.8 * pow(apex_time, 2) / 2);
 }
 
-inline std::array<float, 2> ParticleEngine::color_range() {
-  float min, max;
+inline std::array<double, 2> ParticleEngine::color_range() {
+  double min, max;
   switch (color_param) {
     case PARAMETER::LIFETIME:
       min = 0;
@@ -80,10 +80,10 @@ inline std::array<float, 2> ParticleEngine::color_range() {
       max = 1;
       break;
   }
-  return std::array<float, 2>{min, max};
+  return std::array<double, 2>{min, max};
 }
 
-inline float ParticleEngine::get_particle_value(const Particle& P) {
+inline double ParticleEngine::get_particle_value(const Particle& P) {
   switch (color_param) {
     case PARAMETER::LIFETIME:
       return P.lifetime;
@@ -95,10 +95,12 @@ inline float ParticleEngine::get_particle_value(const Particle& P) {
       return P.pos[1];
       break;
   }
-  return 0.0f;
+  return 0.0;
 }
 
-inline void ParticleEngine::color_particle(Particle& P, float min, float max) {
+inline void ParticleEngine::color_particle(Particle& P,
+                                           double min,
+                                           double max) {
   if (color_mode == COLOR_MODE::CONSTANT)
     return;
 

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -26,7 +26,7 @@ class ParticleEngine : public Entity {
   math::random::RNG_Algorithm random_algorithm =
       math::random::RNG_Algorithm::DEFAULT;
   int max_particles =
-      2500000;  //< Maximum number of particles alive at any given time
+      1000000;  //< Maximum number of particles alive at any given time
   double fire_rate =
       0.001;  //< Minimum delay between the creation of each particle
 
@@ -81,7 +81,7 @@ class ParticleEngine : public Entity {
  public:
   // EMITTER
 
-  int particles_per_second = 1000000;
+  int particles_per_second = 200000;
   float particle_lifetime = 5.0f;  //< Maximum length of time a particle can be
                                    // alive before being cleaned up
 

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -86,6 +86,7 @@ class ParticleEngine : public Entity {
   const std::vector<float>& GetColorBuffer();
   int NumVertices() const;
   int NumParticles() const;
+  int MaxVertices() const;
 
   //~ParticleEngine();
 };

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -31,7 +31,7 @@ class ParticleEngine : public Entity {
   int queued_shots(double time_since);
 
   /*! \brief Create and emit particles based on how much time passed.. */
-  void create_new_particles(double time);
+  void create_new_particles(double time, int count);
 
   /*! \brief Emit as many particles as possible */
   void emit_particle(int num_particles);

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -16,7 +16,7 @@ class ParticleEngine : public Entity {
   enum class PARAMETER { LIFETIME = 0, DIST_FROM_GROUND = 1, VELOCITY = 2 };
 
  public:
-  COLOR_MODE color_mode = COLOR_MODE::RAINBOW;
+  COLOR_MODE color_mode = COLOR_MODE::GRADIENT;
   PARAMETER color_param = PARAMETER::LIFETIME;
   /// PARTICLE
   float coeff_of_restitution = 0.8f;

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -39,12 +39,15 @@ class ParticleEngine : public Entity {
   /*! \brief color particle by this particle engine's color mode. */
   void color_particle(Particle& P);
 
+  /*! \brief Update a particle's position */
+  void update_particle(Particle& P, double time);
+
   /*! \brief Apply simulation to every live particle, detect and remove dead
    * particles, and create new particles */
   void simulate_particles(double time);
 
   /*! Add this particle to the color and position arrays at index i. */
-  void update_arrays(Particle& P, int i);
+  void update_arrays(Particle& P);
 
  public:
   // EMITTER

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -19,6 +19,8 @@ class ParticleEngine : public Entity {
   double overflow = 0.0;
   double last_update = 0.0;
   const double update_threshold = 0.01 / 1000.0;
+  std::vector<float> color_storage;
+  std::vector<float> position_storage;
 
   /*! \brief Determine how many particles should be emitted based on the
    * firerate, time since last update, and number of alive particles. */
@@ -73,8 +75,8 @@ class ParticleEngine : public Entity {
   /*! \brief Update all particles */
   void Update();
 
-  std::vector<float> GetVertexBuffer() const;
-  std::vector<float> GetColorBuffer() const;
+  const std::vector<float>& GetVertexBuffer();
+  const std::vector<float>& GetColorBuffer();
   int NumVertices() const;
 
   //~ParticleEngine();

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -21,6 +21,10 @@ class ParticleEngine : public Entity {
   const double update_threshold = 0.01 / 1000.0;
   std::vector<float> color_storage;
   std::vector<float> position_storage;
+  int num_particles = 0;
+
+  /*! \brief Create a enw particle */
+  Particle gen_particle();
 
   /*! \brief Determine how many particles should be emitted based on the
    * firerate, time since last update, and number of alive particles. */
@@ -78,6 +82,7 @@ class ParticleEngine : public Entity {
   const std::vector<float>& GetVertexBuffer();
   const std::vector<float>& GetColorBuffer();
   int NumVertices() const;
+  int NumParticles() const;
 
   //~ParticleEngine();
 };

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -14,6 +14,23 @@ namespace rpg {
 class ParticleEngine : public Entity {
   enum class COLOR_MODE { CONSTANT = 0, GRADIENT = 1, RAINBOW = 2 };
   enum class PARAMETER { LIFETIME = 0, DIST_FROM_GROUND = 1, VELOCITY = 2 };
+
+ public:
+  COLOR_MODE color_mode = COLOR_MODE::RAINBOW;
+  PARAMETER color_param = PARAMETER::LIFETIME;
+  /// PARTICLE
+  float coeff_of_restitution = 0.8f;
+  bool bounce = true;
+
+  // EMITTER
+  math::random::RNG_Algorithm random_algorithm =
+      math::random::RNG_Algorithm::DEFAULT;
+  int max_particles =
+      2500000;  //< Maximum number of particles alive at any given time
+  double fire_rate =
+      0.001;  //< Minimum delay between the creation of each particle
+
+ private:
   glm::vec3 pos = {0, 0, 0};
   std::vector<Particle> particles;
   double overflow = 0.0;
@@ -63,14 +80,8 @@ class ParticleEngine : public Entity {
 
  public:
   // EMITTER
-  math::random::RNG_Algorithm random_algorithm =
-      math::random::RNG_Algorithm::DEFAULT;
-  int max_particles =
-      15000;  //< Maximum number of particles alive at any given time
-  double fire_rate =
-      0.001;  //< Minimum delay between the creation of each particle
 
-  int particles_per_second = 1000;
+  int particles_per_second = 1000000;
   float particle_lifetime = 5.0f;  //< Maximum length of time a particle can be
                                    // alive before being cleaned up
 
@@ -79,13 +90,6 @@ class ParticleEngine : public Entity {
   RandomOrConstant magnitude;  //< MAgnitude of the initial velocity vector  for
                                // each new particle.
   float horizontal_angle = 360.0f;
-
-  COLOR_MODE color_mode = COLOR_MODE::RAINBOW;
-  PARAMETER color_param = PARAMETER::LIFETIME;
-
-  /// PARTICLE
-  float coeff_of_restitution = 0.8f;
-  bool bounce = true;
 
   // COLORS
   glm::vec3 start_color = glm::vec3{1, 1, 1};

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -39,8 +39,20 @@ class ParticleEngine : public Entity {
   /*! \brief color particle by this particle engine's color mode. */
   void color_particle(Particle& P);
 
+  /*! \brief color particle by this particle engine's color mode. */
+  void color_particle(Particle& P, float min, float max);
+
+  /*! \brief Resize and clear arrays if needed. */
+  void resize_if_needed();
+
   /*! \brief Update a particle's position */
   void update_particle(Particle& P, double time);
+
+  float get_particle_value(const Particle& P);
+
+  /*! \brief Get the current color range depending on which color enums are
+   * specified */
+  std::array<float, 2> color_range();
 
   /*! \brief Apply simulation to every live particle, detect and remove dead
    * particles, and create new particles */

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -57,19 +57,19 @@ class ParticleEngine : public Entity {
   void color_particle(Particle& P);
 
   /*! \brief color particle by this particle engine's color mode. */
-  void color_particle(Particle& P, double min, double max);
+  void color_particle(Particle& P, float min, float max);
 
   /*! \brief Resize and clear arrays if needed. */
   void resize_if_needed();
 
   /*! \brief Update a particle's position */
-  void update_particle(Particle& P, double time);
+  void update_particle(Particle& P, float time);
 
   double get_particle_value(const Particle& P);
 
   /*! \brief Get the current color range depending on which color enums are
    * specified */
-  std::array<double, 2> color_range();
+  std::array<float, 2> color_range();
 
   /*! \brief Apply simulation to every live particle, detect and remove dead
    * particles, and create new particles */

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -57,7 +57,7 @@ class ParticleEngine : public Entity {
   void color_particle(Particle& P);
 
   /*! \brief color particle by this particle engine's color mode. */
-  void color_particle(Particle& P, float min, float max);
+  void color_particle(Particle& P, double min, double max);
 
   /*! \brief Resize and clear arrays if needed. */
   void resize_if_needed();
@@ -65,11 +65,11 @@ class ParticleEngine : public Entity {
   /*! \brief Update a particle's position */
   void update_particle(Particle& P, double time);
 
-  float get_particle_value(const Particle& P);
+  double get_particle_value(const Particle& P);
 
   /*! \brief Get the current color range depending on which color enums are
    * specified */
-  std::array<float, 2> color_range();
+  std::array<double, 2> color_range();
 
   /*! \brief Apply simulation to every live particle, detect and remove dead
    * particles, and create new particles */

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -43,6 +43,9 @@ class ParticleEngine : public Entity {
    * particles, and create new particles */
   void simulate_particles(double time);
 
+  /*! Add this particle to the color and position arrays at index i. */
+  void update_arrays(Particle& P, int i);
+
  public:
   // EMITTER
   math::random::RNG_Algorithm random_algorithm =

--- a/src/entities/particle_system.h
+++ b/src/entities/particle_system.h
@@ -35,7 +35,7 @@ class ParticleEngine : public Entity {
   std::vector<Particle> particles;
   double overflow = 0.0;
   double last_update = 0.0;
-  const double update_threshold = 0.01 / 1000.0;
+  const double update_threshold = 0.005 / 1000.0;
   std::vector<float> color_storage;
   std::vector<float> position_storage;
   int num_particles = 0;

--- a/src/math/color.h
+++ b/src/math/color.h
@@ -80,15 +80,15 @@ inline void hsv_to_rgb_simplified(Numeric auto& h,
 
 /*! \brief Convert a vector3D to rgb */
 inline void hsv_to_rgb(Vector3D auto& hsv_color) {
-  Numeric auto h = get(hsv_color, 0);
-  Numeric auto s = get(hsv_color, 1);
-  Numeric auto v = get(hsv_color, 2);
+  Numeric auto h = get<0>(hsv_color);
+  Numeric auto s = get<1>(hsv_color);
+  Numeric auto v = get<2>(hsv_color);
 
   hsv_to_rgb_simplified(h, s, v);
 
-  set(hsv_color, 0, h);
-  set(hsv_color, 1, s);
-  set(hsv_color, 2, v);
+  set<0>(hsv_color, h);
+  set<1>(hsv_color, s);
+  set<2>(hsv_color, v);
 }
 
 }  // namespace rpg::math::color

--- a/src/math/color.h
+++ b/src/math/color.h
@@ -78,72 +78,55 @@ inline void hsv_to_rgb_simplified(Numeric auto& h,
   v = alt_function(1.0, H, S, V);
 }
 
-inline void hsv_to_rgb_char(unsigned char& h,
-                            unsigned char& s,
-                            unsigned char& v) {
-  const auto H = h;
-  const auto S = s;
-  const auto V = v;
+inline std::array<unsigned char, 3> hsv_to_rgb_char(unsigned char h,
+                                                    unsigned char s,
+                                                    unsigned char v) {
+  const unsigned char region = h / 43;
+  const unsigned char remainder = (h - (region * 43)) * 6;
 
-  const auto region = h / 43;
-  const auto remainder = (h - (region * 43)) * 6;
-
-  const auto p = (v * (255 - s)) >> 8;
-  const auto q = (v * (255 - ((s * remainder) >> 8))) >> 8;
-  const auto t = (v * (255 - ((s * (255 - remainder)) >> 8))) >> 8;
+  const unsigned char p = (v * (255 - s)) >> 8;
+  const unsigned char q = (v * (255 - ((s * remainder) >> 8))) >> 8;
+  const unsigned char t = (v * (255 - ((s * (255 - remainder)) >> 8))) >> 8;
 
   switch (region) {
     case 0:
-      h = V;
-      s = t;
-      v = p;
+      return {v, t, p};
       break;
     case 1:
-      h = q;
-      s = V;
-      v = p;
+      return {q, v, p};
       break;
     case 2:
-      h = p;
-      s = V;
-      v = t;
+      return {p, v, t};
       break;
     case 3:
-      h = p;
-      s = q;
-      v = V;
+      return {p, q, v};
       break;
     case 4:
-      h = t;
-      s = p;
-      v = V;
+      return {t, p, q};
       break;
     default:
-      h = V;
-      s = p;
-      v = q;
+      return {v, p, q};
       break;
   }
 }
 
-inline unsigned char double_to_char(double f) {
-  return static_cast<unsigned char>(f * 255.0);
+inline unsigned char float_to_char(Numeric auto f) {
+  return static_cast<unsigned char>(f * 255.0f);
+}
+inline float char_to_float(unsigned char f) {
+  return static_cast<float>(f) / 255.0f;
 }
 
-inline float char_to_double(unsigned char c) {
-  return static_cast<double>(c) / 255.0;
-}
+inline auto hsv_to_rgb_char(Numeric auto h, Numeric auto s, Numeric auto v) {
+  const auto H = float_to_char(h);
+  const auto S = float_to_char(s);
+  const auto V = float_to_char(v);
 
-inline void hsv_to_rgb_char(Numeric auto& h, Numeric auto& s, Numeric auto& v) {
-  auto H = double_to_char(h);
-  auto S = double_to_char(s);
-  auto V = double_to_char(v);
+  const std::array<unsigned char, 3> rgb = hsv_to_rgb_char(H, S, V);
 
-  hsv_to_rgb_char(H, S, V);
-
-  h = char_to_double(H);
-  s = char_to_double(S);
-  v = char_to_double(V);
+  return std::array<decltype(h), 3>{char_to_float(rgb[0]),
+                                    s = char_to_float(rgb[1]),
+                                    v = char_to_float(rgb[2])};
 }
 
 /*! \brief Convert a vector3D to rgb */
@@ -152,11 +135,11 @@ inline void hsv_to_rgb(Vector3D auto& hsv_color) {
   Numeric auto s = get<1>(hsv_color);
   Numeric auto v = get<2>(hsv_color);
 
-  hsv_to_rgb_char(h, s, v);
+  const auto rgb = hsv_to_rgb_char(h, s, v);
 
-  set<0>(hsv_color, h);
-  set<1>(hsv_color, s);
-  set<2>(hsv_color, v);
+  set<0>(hsv_color, rgb[0]);
+  set<1>(hsv_color, rgb[1]);
+  set<2>(hsv_color, rgb[2]);
 }
 
 }  // namespace rpg::math::color

--- a/src/math/color.h
+++ b/src/math/color.h
@@ -78,13 +78,81 @@ inline void hsv_to_rgb_simplified(Numeric auto& h,
   v = alt_function(1.0, H, S, V);
 }
 
+inline void hsv_to_rgb_char(unsigned char& h,
+                            unsigned char& s,
+                            unsigned char& v) {
+  const auto H = h;
+  const auto S = s;
+  const auto V = v;
+
+  const auto region = h / 43;
+  const auto remainder = (h - (region * 43)) * 6;
+
+  const auto p = (v * (255 - s)) >> 8;
+  const auto q = (v * (255 - ((s * remainder) >> 8))) >> 8;
+  const auto t = (v * (255 - ((s * (255 - remainder)) >> 8))) >> 8;
+
+  switch (region) {
+    case 0:
+      h = V;
+      s = t;
+      v = p;
+      break;
+    case 1:
+      h = q;
+      s = V;
+      v = p;
+      break;
+    case 2:
+      h = p;
+      s = V;
+      v = t;
+      break;
+    case 3:
+      h = p;
+      s = q;
+      v = V;
+      break;
+    case 4:
+      h = t;
+      s = p;
+      v = V;
+      break;
+    default:
+      h = V;
+      s = p;
+      v = q;
+      break;
+  }
+}
+
+inline unsigned char double_to_char(double f) {
+  return static_cast<unsigned char>(f * 255.0);
+}
+
+inline float char_to_double(unsigned char c) {
+  return static_cast<double>(c) / 255.0;
+}
+
+inline void hsv_to_rgb_char(Numeric auto& h, Numeric auto& s, Numeric auto& v) {
+  auto H = double_to_char(h);
+  auto S = double_to_char(s);
+  auto V = double_to_char(v);
+
+  hsv_to_rgb_char(H, S, V);
+
+  h = char_to_double(H);
+  s = char_to_double(S);
+  v = char_to_double(V);
+}
+
 /*! \brief Convert a vector3D to rgb */
 inline void hsv_to_rgb(Vector3D auto& hsv_color) {
   Numeric auto h = get<0>(hsv_color);
   Numeric auto s = get<1>(hsv_color);
   Numeric auto v = get<2>(hsv_color);
 
-  hsv_to_rgb_simplified(h, s, v);
+  hsv_to_rgb_char(h, s, v);
 
   set<0>(hsv_color, h);
   set<1>(hsv_color, s);

--- a/src/math/color.h
+++ b/src/math/color.h
@@ -19,7 +19,7 @@ inline void hsv_to_rgb(Numeric auto& h, Numeric auto& s, Numeric auto& v) {
   h = h * 360.0;
   const double h_prime = h / 60.0;
   const double chroma = v * s;
-  const double x = chroma * (1 - abs(std::fmod(h_prime, 2) - 1));
+  const double x = chroma * (1.0 - abs(std::fmod(h_prime, 2.0) - 1.0));
 
   const double m = v - chroma;
 

--- a/src/math/vector3d.h
+++ b/src/math/vector3d.h
@@ -132,13 +132,12 @@ inline constexpr auto multiply(T v1, const V& v2) {
   return T{x, y, z};
 }
 
-template <Vector3D T, Numeric S>
-inline constexpr auto multiply(T v1, S scalar) {
+inline constexpr auto multiply(const Vector3D auto v1, Numeric auto scalar) {
   const Numeric auto x = get<0>(v1) * scalar;
   const Numeric auto y = get<1>(v1) * scalar;
   const Numeric auto z = get<2>(v1) * scalar;
 
-  return T{x, y, z};
+  return decltype(v1){x, y, z};
 }
 
 template <Numeric T>

--- a/src/math/vector3d.h
+++ b/src/math/vector3d.h
@@ -102,8 +102,7 @@ inline constexpr void set(Vector3DBoth auto& st, Numeric auto value) {
 
 /*! \brief Convert 3 coordinates from a spherical coordinate system to a
  * cartesian coordinate system */
-inline constexpr Vector3D auto spherical_to_cartesian(
-    const Vector3D auto& coord) {
+inline constexpr Vector3D auto spherical_to_cartesian(Vector3D auto coord) {
   const Numeric auto rho = get<0>(coord);
   const Numeric auto theta = get<1>(coord);
   const Numeric auto phi = get<2>(coord);
@@ -116,7 +115,7 @@ inline constexpr Vector3D auto spherical_to_cartesian(
 }
 
 template <Vector3D T, Vector3D V>
-inline constexpr Vector3D auto add(const T& v1, const V& v2) {
+inline constexpr Vector3D auto add(T v1, V v2) {
   const Numeric auto x = get<0>(v1) + get<0>(v2);
   const Numeric auto y = get<1>(v1) + get<1>(v2);
   const Numeric auto z = get<2>(v1) + get<2>(v2);
@@ -125,19 +124,19 @@ inline constexpr Vector3D auto add(const T& v1, const V& v2) {
 }
 
 template <Vector3D T, Vector3D V>
-inline constexpr auto multiply(const T& v1, const V& v2) {
-  const auto x = get(v1, 0) * get(v2, 0);
-  const auto y = get(v1, 1) * get(v2, 1);
-  const auto z = get(v1, 2) * get(v2, 2);
+inline constexpr auto multiply(T v1, const V& v2) {
+  const Numeric auto x = get(v1, 0) * get(v2, 0);
+  const Numeric auto y = get(v1, 1) * get(v2, 1);
+  const Numeric auto z = get(v1, 2) * get(v2, 2);
 
   return T{x, y, z};
 }
 
 template <Vector3D T, Numeric S>
-inline constexpr auto multiply(const T& v1, S scalar) {
-  const auto x = get<0>(v1) * scalar;
-  const auto y = get<1>(v1) * scalar;
-  const auto z = get<2>(v1) * scalar;
+inline constexpr auto multiply(T v1, S scalar) {
+  const Numeric auto x = get<0>(v1) * scalar;
+  const Numeric auto y = get<1>(v1) * scalar;
+  const Numeric auto z = get<2>(v1) * scalar;
 
   return T{x, y, z};
 }

--- a/src/math/vector3d.h
+++ b/src/math/vector3d.h
@@ -47,12 +47,12 @@ auto get(int i, const T& st) {
 }
 
 template <Vector3DArray T>
-inline auto get(const T& st, int i) {
+inline Numeric auto get(const T& st, int i) {
   return st[i];
 }
 
 template <Vector3DStruct T, Numeric N>
-inline void set(T& st, int i, N value) {
+inline constexpr void set(T& st, int i, N value) {
   switch (i) {
     case 0:
       st.x = value;
@@ -70,30 +70,30 @@ inline void set(T& st, int i, N value) {
 }
 
 template <Vector3DArray T, Numeric N>
-inline auto set(const T& st, int i, N value) {
+inline constexpr auto set(const T& st, int i, N value) {
   st[i] = value;
 }
 
 /*! \brief Convert 3 coordinates from a spherical coordinate system to a
  * cartesian coordinate system */
 template <Vector3D T>
-inline auto spherical_to_cartesian(const T coord) {
-  const auto rho = get(coord, 0);
-  const auto theta = get(coord, 1);
-  const auto phi = get(coord, 2);
+inline constexpr Vector3D auto spherical_to_cartesian(const T coord) {
+  const Numeric auto rho = get(coord, 0);
+  const Numeric auto theta = get(coord, 1);
+  const Numeric auto phi = get(coord, 2);
 
-  const auto x = rho * sin(phi) * cos(theta);
-  const auto y = rho * sin(phi) * sin(theta);
-  const auto z = rho * cos(phi);
+  const Numeric auto x = rho * sin(phi) * cos(theta);
+  const Numeric auto y = rho * sin(phi) * sin(theta);
+  const Numeric auto z = rho * cos(phi);
 
   return T{x, y, z};
 }
 
 template <Vector3D T, Vector3D V>
 inline auto add(const T& v1, const V& v2) {
-  const auto x = get(v1, 0) + get(v2, 0);
-  const auto y = get(v1, 1) + get(v2, 1);
-  const auto z = get(v1, 2) + get(v2, 2);
+  const Numeric auto x = get(v1, 0) + get(v2, 0);
+  const Numeric auto y = get(v1, 1) + get(v2, 1);
+  const Numeric auto z = get(v1, 2) + get(v2, 2);
 
   return T{x, y, z};
 }

--- a/src/math/vector3d.h
+++ b/src/math/vector3d.h
@@ -25,10 +25,13 @@ concept Vector3DArray = requires(T a) {
 };
 
 template <typename T>
+concept Vector3DBoth = Vector3DArray<T>&& Vector3DStruct<T>;
+
+template <typename T>
 concept Vector3D = Vector3DStruct<T> || Vector3DArray<T>;
 
-template <Vector3DStruct T>
-auto get(int i, const T& st) {
+template <int i>
+inline Numeric auto constexpr get(const Vector3DStruct auto& st) {
   switch (i) {
     case 0:
       return st.x;
@@ -39,20 +42,31 @@ auto get(int i, const T& st) {
     case 2:
       return st.z;
       break;
-    default:
-      assert(false);
-      return std::numeric_limits<float>::infinity();
-      break;
   }
 }
 
-template <Vector3DArray T>
-inline Numeric auto get(const T& st, int i) {
+template <int i>
+inline constexpr Numeric auto get(const Vector3DArray auto& st) {
   return st[i];
 }
 
-template <Vector3DStruct T, Numeric N>
-inline constexpr void set(T& st, int i, N value) {
+template <int i>
+inline constexpr Numeric auto get(const Vector3DBoth auto& st) {
+  switch (i) {
+    case 0:
+      return st.x;
+      break;
+    case 1:
+      return st.y;
+      break;
+    case 2:
+      return st.z;
+      break;
+  };
+}
+
+template <int i, Vector3DStruct T, Numeric N>
+inline constexpr void set(T& st, N value) {
   switch (i) {
     case 0:
       st.x = value;
@@ -63,43 +77,55 @@ inline constexpr void set(T& st, int i, N value) {
     case 2:
       st.z = value;
       break;
-    default:
-      assert(false);
+  }
+}
+
+template <int i, Vector3DArray T, Numeric N>
+inline constexpr void set(T& st, N value) {
+  st[i] = value;
+}
+
+template <int i>
+inline constexpr void set(Vector3DBoth auto& st, Numeric auto value) {
+  switch (i) {
+    case 0:
+      st.x = value;
+      break;
+    case 1:
+      st.y = value;
+      break;
+    case 2:
+      st.z = value;
       break;
   }
 }
 
-template <Vector3DArray T, Numeric N>
-inline constexpr auto set(const T& st, int i, N value) {
-  st[i] = value;
-}
-
 /*! \brief Convert 3 coordinates from a spherical coordinate system to a
  * cartesian coordinate system */
-template <Vector3D T>
-inline constexpr Vector3D auto spherical_to_cartesian(const T coord) {
-  const Numeric auto rho = get(coord, 0);
-  const Numeric auto theta = get(coord, 1);
-  const Numeric auto phi = get(coord, 2);
+inline constexpr Vector3D auto spherical_to_cartesian(
+    const Vector3D auto& coord) {
+  const Numeric auto rho = get<0>(coord);
+  const Numeric auto theta = get<1>(coord);
+  const Numeric auto phi = get<2>(coord);
 
   const Numeric auto x = rho * sin(phi) * cos(theta);
   const Numeric auto y = rho * sin(phi) * sin(theta);
   const Numeric auto z = rho * cos(phi);
 
+  return decltype(coord){x, y, z};
+}
+
+template <Vector3D T, Vector3D V>
+inline constexpr Vector3D auto add(const T& v1, const V& v2) {
+  const Numeric auto x = get<0>(v1) + get<0>(v2);
+  const Numeric auto y = get<1>(v1) + get<1>(v2);
+  const Numeric auto z = get<2>(v1) + get<2>(v2);
+
   return T{x, y, z};
 }
 
 template <Vector3D T, Vector3D V>
-inline auto add(const T& v1, const V& v2) {
-  const Numeric auto x = get(v1, 0) + get(v2, 0);
-  const Numeric auto y = get(v1, 1) + get(v2, 1);
-  const Numeric auto z = get(v1, 2) + get(v2, 2);
-
-  return T{x, y, z};
-}
-
-template <Vector3D T, Vector3D V>
-inline auto multiply(const T& v1, const V& v2) {
+inline constexpr auto multiply(const T& v1, const V& v2) {
   const auto x = get(v1, 0) * get(v2, 0);
   const auto y = get(v1, 1) * get(v2, 1);
   const auto z = get(v1, 2) * get(v2, 2);
@@ -108,21 +134,21 @@ inline auto multiply(const T& v1, const V& v2) {
 }
 
 template <Vector3D T, Numeric S>
-inline auto multiply(const T& v1, S scalar) {
-  const auto x = get(v1, 0) * scalar;
-  const auto y = get(v1, 1) * scalar;
-  const auto z = get(v1, 2) * scalar;
+inline constexpr auto multiply(const T& v1, S scalar) {
+  const auto x = get<0>(v1) * scalar;
+  const auto y = get<1>(v1) * scalar;
+  const auto z = get<2>(v1) * scalar;
 
   return T{x, y, z};
 }
 
 template <Numeric T>
-auto magnitude(T x, T y, T z) {
+inline constexpr Numeric auto magnitude(T x, T y, T z) {
   return sqrt(pow(x, 2) + pow(y, 2) + pow(z, 2));
 }
 
 template <Vector3D T>
-auto magnitude(const T& vector) {
+inline constexpr Numeric auto magnitude(const T& vector) {
   const auto x = get(vector, 0);
   const auto y = get(vector, 1);
   const auto z = get(vector, 2);
@@ -130,15 +156,16 @@ auto magnitude(const T& vector) {
   return magnitude(x, y, z);
 }
 
-inline void normalize(Vector3D auto& v) {
-  const auto mag = magnitude(v);
+inline constexpr void normalize(Vector3D auto& v) {
+  const Numeric auto mag = magnitude(v);
 
   set(v, 0, get(v, 0) / mag);
   set(v, 1, get(v, 1) / mag);
   set(v, 2, get(v, 2) / mag);
 }
 
-inline void set_magnitude(Vector3D auto& v, Numeric auto new_magnitude) {
+inline constexpr void set_magnitude(Vector3D auto& v,
+                                    Numeric auto new_magnitude) {
   normalize(v);
 
   set(v, 0, get(v, 0) * new_magnitude);

--- a/src/menus/settings.cpp
+++ b/src/menus/settings.cpp
@@ -61,7 +61,7 @@ void InitParticleMenu(rpg::ParticleEngine* PE) {
 
   vector<Widget*> particle_system{
       new Slider(
-          "Number of Particles", &PE->max_particles, 1, 2500000,
+          "Number of Particles", &PE->max_particles, 1, 1000000,
           "Maximum number of particles that can be alive at any time. Once "
           "this cap is reached, no more particles will be created."),
       new Slider("Particle Lifetime", &PE->particle_lifetime, 0.1, 10,
@@ -70,7 +70,7 @@ void InitParticleMenu(rpg::ParticleEngine* PE) {
       new Slider("Horizontal Angle", &PE->horizontal_angle, 0, 360),
       BindRandomOrConstant(PE->vertical_angle, "Vertical Angle"),
       BindRandomOrConstant(PE->magnitude, "Magnitude"),
-      new Slider("Particles Per Second", &PE->particles_per_second, 1, 500000,
+      new Slider("Particles Per Second", &PE->particles_per_second, 1, 200000,
                  "Number of particles that can be created per second.")};
 
   vector<Widget*> physics = {new AlternateWidget(

--- a/src/menus/settings.cpp
+++ b/src/menus/settings.cpp
@@ -61,7 +61,7 @@ void InitParticleMenu(rpg::ParticleEngine* PE) {
 
   vector<Widget*> particle_system{
       new Slider(
-          "Number of Particles", &PE->max_particles, 1, 1000000,
+          "Number of Particles", &PE->max_particles, 1, 10000000,
           "Maximum number of particles that can be alive at any time. Once "
           "this cap is reached, no more particles will be created."),
       new Slider("Particle Lifetime", &PE->particle_lifetime, 0.1, 10,
@@ -70,7 +70,7 @@ void InitParticleMenu(rpg::ParticleEngine* PE) {
       new Slider("Horizontal Angle", &PE->horizontal_angle, 0, 360),
       BindRandomOrConstant(PE->vertical_angle, "Vertical Angle"),
       BindRandomOrConstant(PE->magnitude, "Magnitude"),
-      new Slider("Particles Per Second", &PE->particles_per_second, 1, 100000,
+      new Slider("Particles Per Second", &PE->particles_per_second, 1, 500000,
                  "Number of particles that can be created per second.")};
 
   vector<Widget*> physics = {new AlternateWidget(

--- a/src/menus/settings.cpp
+++ b/src/menus/settings.cpp
@@ -56,7 +56,8 @@ void InitParticleMenu(rpg::ParticleEngine* PE) {
       color_pickers};
 
   vector<Widget*> simulation = {
-      new Slider("Simulation Speed", &rpg::simulation::time_scale, 0.0f, 2.0f),
+      new Slider("Simulation Speed", &rpg::simulation::time_scale, 0.001f,
+                 2.0f),
       new CheckBox("Enable Floor", &PE->bounce)};
 
   vector<Widget*> particle_system{

--- a/src/menus/settings.cpp
+++ b/src/menus/settings.cpp
@@ -26,7 +26,7 @@ using std::vector;
 namespace rpg::menus {
 
 std::string GetParticleCount(ParticleEngine* ps) {
-  return "Particle Count: " + std::to_string(ps->NumVertices());
+  return "Particle Count: " + std::to_string(ps->NumVertices() / 3);
 }
 
 /*! \brief Create a prebaked group to bind all parameters in a random or

--- a/src/menus/settings.cpp
+++ b/src/menus/settings.cpp
@@ -61,7 +61,7 @@ void InitParticleMenu(rpg::ParticleEngine* PE) {
 
   vector<Widget*> particle_system{
       new Slider(
-          "Number of Particles", &PE->max_particles, 1, 10000000,
+          "Number of Particles", &PE->max_particles, 1, 2500000,
           "Maximum number of particles that can be alive at any time. Once "
           "this cap is reached, no more particles will be created."),
       new Slider("Particle Lifetime", &PE->particle_lifetime, 0.1, 10,

--- a/src/physics/kinematics.h
+++ b/src/physics/kinematics.h
@@ -7,8 +7,8 @@
 namespace rpg::physics {
 using namespace rpg::math;
 
-static const double gravitational_constant = 9.81;
-static const std::array<double, 3> Fg = {0, -gravitational_constant, 0};
+static const float gravitational_constant = 9.81;
+static const std::array<float, 3> Fg = {0, -gravitational_constant, 0};
 
 template <Vector3D K, Numeric seconds>
 inline void apply_velocity(K& position, const K& velocity, seconds S) {
@@ -23,13 +23,12 @@ inline void apply_gravity(K& velocity, seconds s) {
 inline void update_position_with_gravity(Vector3D auto& position,
                                          Vector3D auto& velocity,
                                          Numeric auto time) {
-  const double seconds = static_cast<double>(time);
   const Vector3D auto gravity_accel =
-      multiply(multiply(Fg, pow(seconds, 2)), 0.5);
-  const Vector3D auto change_due_to_velocity = multiply(velocity, seconds);
+      multiply(multiply(Fg, powf(time, 2)), 0.5f);
+  const Vector3D auto change_due_to_velocity = multiply(velocity, time);
 
   position = add(add(position, change_due_to_velocity), gravity_accel);
-  velocity = add(velocity, multiply(Fg, seconds));
+  velocity = add(velocity, multiply(Fg, time));
 }
 
 inline constexpr Numeric auto kinematic_energy(Numeric auto velocity_magnitude,

--- a/src/physics/kinematics.h
+++ b/src/physics/kinematics.h
@@ -15,20 +15,23 @@ inline void apply_velocity(K& position, const K& velocity, seconds S) {
   change_over_time(position, velocity, S);
 }
 
-template <Vector3D K, Numeric seconds>
-inline void apply_gravity(K& velocity, seconds s) {
-  change_over_time(velocity, Fg, s);
+inline void apply_gravity(Vector3D auto& position,
+                          Vector3D auto& velocity,
+                          const Numeric auto& time) {
+  const Vector3D auto gravity_accel =
+      multiply(multiply(Fg, pow(time, 2)), 0.5f);
+
+  position = add(position, gravity_accel);
+  velocity = add(velocity, multiply(Fg, time));
 }
 
 inline void update_position_with_gravity(Vector3D auto& position,
                                          Vector3D auto& velocity,
                                          Numeric auto time) {
-  const Vector3D auto gravity_accel =
-      multiply(multiply(Fg, powf(time, 2)), 0.5f);
   const Vector3D auto change_due_to_velocity = multiply(velocity, time);
+  position = add(position, change_due_to_velocity);
 
-  position = add(add(position, change_due_to_velocity), gravity_accel);
-  velocity = add(velocity, multiply(Fg, time));
+  apply_gravity(position, velocity, time);
 }
 
 inline constexpr Numeric auto kinematic_energy(Numeric auto velocity_magnitude,

--- a/src/physics/kinematics.h
+++ b/src/physics/kinematics.h
@@ -17,9 +17,9 @@ inline void apply_velocity(K& position, const K& velocity, seconds S) {
 
 inline void apply_gravity(Vector3D auto& position,
                           Vector3D auto& velocity,
-                          const Numeric auto& time) {
+                          const Numeric auto time) {
   const Vector3D auto gravity_accel =
-      multiply(multiply(Fg, pow(time, 2)), 0.5f);
+      multiply(multiply(Fg, powf(time, 2)), 0.5f);
 
   position = add(position, gravity_accel);
   velocity = add(velocity, multiply(Fg, time));

--- a/src/physics/kinematics.h
+++ b/src/physics/kinematics.h
@@ -7,8 +7,8 @@
 namespace rpg::physics {
 using namespace rpg::math;
 
-const double gravitational_constant = 9.81;
-const std::array<double, 3> Fg = {0, -gravitational_constant, 0};
+static const double gravitational_constant = 9.81;
+static const std::array<double, 3> Fg = {0, -gravitational_constant, 0};
 
 template <Vector3D K, Numeric seconds>
 inline void apply_velocity(K& position, const K& velocity, seconds S) {
@@ -32,23 +32,25 @@ inline void update_position_with_gravity(Vector3D auto& position,
   velocity = add(velocity, multiply(Fg, seconds));
 }
 
-inline auto kinematic_energy(Numeric auto velocity_magnitude,
-                             Numeric auto mass) {
+inline constexpr Numeric auto kinematic_energy(Numeric auto velocity_magnitude,
+                                               Numeric auto mass) {
   return (mass * pow(velocity_magnitude, 2) / static_cast<decltype(mass)>(2));
 }
 
 /*! \brief Calculate the current kinematic energy of a body */
-inline auto kinematic_energy(const Vector3D auto& velocity, Numeric auto mass) {
-  const auto velocity_magnitude = magnitude(velocity);
+inline constexpr Numeric auto kinematic_energy(const Vector3D auto& velocity,
+                                               Numeric auto mass) {
+  const Numeric auto velocity_magnitude = magnitude(velocity);
   return kinematic_energy(velocity_magnitude, mass);
 }
 
-inline auto velocity_from_kinematic_energy(Numeric auto kinematic_energy,
-                                           Numeric auto mass) {
+inline constexpr Numeric auto velocity_from_kinematic_energy(
+    Numeric auto kinematic_energy,
+    Numeric auto mass) {
   return sqrt(2.0 * kinematic_energy / mass);
 }
 
-inline constexpr auto calculate_energy_loss(Numeric auto e) {
+inline constexpr Numeric auto calculate_energy_loss(Numeric auto e) {
   return (1.0 - pow(e, 2));
 }
 

--- a/src/physics/rigid_body.h
+++ b/src/physics/rigid_body.h
@@ -33,7 +33,7 @@ inline void bounce_basic(RigidBody auto& body,
                          Numeric auto collision_pos = 0.0,
                          Numeric auto time_since_last_update = -1) {
   // Do nothing if the particle has no vertical momentum
-  double time_since = static_cast<double>(time_since_last_update);
+  double time_since = time_since_last_update;
   double y_vel = abs(get(body.velocity, 1));
 
   const double distance_underground = abs(collision_pos - get(body.pos, 1));

--- a/src/physics/rigid_body.h
+++ b/src/physics/rigid_body.h
@@ -49,10 +49,11 @@ inline void bounce_basic(RigidBody auto& body,
     return;
   }
 
-  auto y_vel = abs(get<1>(body.velocity));
-  double time_since = time_since_last_update;
-  const double distance_underground = abs(collision_pos - get<1>(body.pos));
-  const double time_since_collision = distance_underground / y_vel;
+  Numeric auto y_vel = abs(get<1>(body.velocity));
+  Numeric auto time_since = time_since_last_update;
+  const Numeric auto distance_underground =
+      abs(collision_pos - get<1>(body.pos));
+  const Numeric auto time_since_collision = distance_underground / y_vel;
 
   if (time_since_collision > time_since) {
     set_grounded(body);
@@ -66,9 +67,9 @@ inline void bounce_basic(RigidBody auto& body,
   // Calculate how much energy was lost with the bounce
   y_vel = get<1>(body.velocity);
 
-  const double energy = kinematic_energy(y_vel, mass);
-  const double energy_loss = calculate_energy_loss(e);
-  const double energy_after_bounce = energy - (energy_loss * energy);
+  const Numeric auto energy = kinematic_energy(y_vel, mass);
+  const Numeric auto energy_loss = calculate_energy_loss(e);
+  const Numeric auto energy_after_bounce = energy - (energy_loss * energy);
 
   // Update the velocity of the body based on the new energy
   const double velocity_after_bounce =

--- a/src/physics/rigid_body.h
+++ b/src/physics/rigid_body.h
@@ -32,23 +32,33 @@ inline void set_grounded(RigidBody auto& body) {
   set<1>(body.pos, 0);
 }
 
+enum class BODY_STATE { COLLIDING = 0, GROUNDED = 1, AIRBORNE = 2 };
+
+constexpr inline BODY_STATE check_state(const Vector3D auto& pos,
+                                        const Vector3D auto& velocity,
+                                        float ground_pos) {
+  const float grounded_threshold = 0.01f;
+  const Numeric auto y_pos = get<1>(pos);
+  const Numeric auto y_velocity = get<1>(velocity);
+
+  const bool is_above_ground = y_pos > ground_pos;
+  const bool has_upward_velocity = y_velocity > 0;
+  const bool is_within_grounded_threshold = y_velocity > -grounded_threshold;
+
+  if (is_above_ground || has_upward_velocity)
+    return BODY_STATE::AIRBORNE;
+  else if (is_within_grounded_threshold)
+    return BODY_STATE::GROUNDED;
+  else
+    return BODY_STATE::COLLIDING;
+}
+
 inline void bounce_basic(RigidBody auto& body,
                          Numeric auto mass = 5.0,
                          Numeric auto e = 0,
                          Numeric auto collision_pos = 0.0,
                          Numeric auto time_since_last_update = 0.0) {
   // Minimum velocity
-  static const float grounded_threshold = 0.01f;
-
-  // Return if there's no possible collision
-  if (get<1>(body.pos) > collision_pos || get<1>(body.velocity) > 0)
-    return;
-  // Otherwise check if the particle should be grounded
-  else if (get<1>(body.velocity) > -grounded_threshold) {
-    set_grounded(body);
-    return;
-  }
-
   Numeric auto y_vel = abs(get<1>(body.velocity));
   Numeric auto time_since = time_since_last_update;
   const Numeric auto distance_underground =
@@ -72,7 +82,7 @@ inline void bounce_basic(RigidBody auto& body,
   const Numeric auto energy_after_bounce = energy - (energy_loss * energy);
 
   // Update the velocity of the body based on the new energy
-  const double velocity_after_bounce =
+  const Numeric auto velocity_after_bounce =
       velocity_from_kinematic_energy(energy_after_bounce, mass);
   set<1>(body.velocity, velocity_after_bounce);
 
@@ -81,5 +91,32 @@ inline void bounce_basic(RigidBody auto& body,
   physics::update_position_with_gravity(
       body.pos, body.velocity,
       std::min(time_since_collision, time_since_last_update));
+}
+
+/*! \brief Full cycle physics step containing all phenomena */
+inline void full_simulation_step(RigidBody auto& body,
+                                 bool enable_bounce = true,
+                                 Numeric auto mass = 5.0f,
+                                 Numeric auto e = 0.0f,
+                                 Numeric auto ground_pos = 0.0f,
+                                 Numeric auto time = 0.0f) {
+  // Update position based on velocity since this is always relevant
+  const Vector3D auto change_due_to_velocity = multiply(body.velocity, time);
+  body.pos = add(body.pos, change_due_to_velocity);
+  apply_gravity(body.pos, body.velocity, time);
+  const auto state = check_state(body.pos, body.velocity, ground_pos);
+
+  switch (state) {
+    case BODY_STATE::GROUNDED:
+      set_grounded(body);
+      break;
+    case BODY_STATE::COLLIDING:
+      if (enable_bounce) {
+        bounce_basic(body, 0.5f, e, ground_pos, time);
+      }
+      break;
+    case BODY_STATE::AIRBORNE:
+      break;
+  }
 }
 }  // namespace rpg::physics

--- a/src/physics/rigid_body.h
+++ b/src/physics/rigid_body.h
@@ -34,9 +34,9 @@ inline void bounce_basic(RigidBody auto& body,
                          Numeric auto time_since_last_update = -1) {
   // Do nothing if the particle has no vertical momentum
   double time_since = time_since_last_update;
-  double y_vel = abs(get(body.velocity, 1));
+  double y_vel = abs(get<1>(body.velocity));
 
-  const double distance_underground = abs(collision_pos - get(body.pos, 1));
+  const double distance_underground = abs(collision_pos - get<1>(body.pos));
   const double time_since_collision = distance_underground / y_vel;
 
   // If time_since_last_update is unset, set it to time_since_collision to
@@ -44,8 +44,8 @@ inline void bounce_basic(RigidBody auto& body,
   if (time_since == -1)
     time_since = time_since_collision;
   else if (time_since_collision > time_since || (abs(y_vel) <= 0.001)) {
-    set(body.velocity, 1, 0);
-    set(body.pos, 1, 0);
+    set<0>(body.velocity, 0);
+    set<1>(body.pos, 0);
 
     return;
   }
@@ -63,7 +63,7 @@ inline void bounce_basic(RigidBody auto& body,
   // Update the velocity of the body based on the new energy
   const double velocity_after_bounce =
       velocity_from_kinematic_energy(energy_after_bounce, mass);
-  set(body.velocity, 1, velocity_after_bounce);
+  set<1>(body.velocity, velocity_after_bounce);
 
   // Now play the motion of the object since the time of impact with the new
   // velocity

--- a/src/physics/rigid_body.h
+++ b/src/physics/rigid_body.h
@@ -54,7 +54,7 @@ inline void bounce_basic(RigidBody auto& body,
   physics::update_position_with_gravity(body.pos, body.velocity,
                                         -time_since_collision);
   // Calculate how much energy was lost with the bounce
-  y_vel = body.velocity.y;
+  y_vel = get<1>(body.velocity);
 
   const double energy = kinematic_energy(y_vel, mass);
   const double energy_loss = calculate_energy_loss(e);

--- a/src/random_or_constant.h
+++ b/src/random_or_constant.h
@@ -28,6 +28,14 @@ namespace rpg {
    get_number
 */
 class RandomOrConstant {
+ public:
+  bool use_random = false;
+  float constant;
+  float scale_factor = 1;
+
+  float min_value, max_value;
+  float rand_min, rand_max;
+
  private:
   std::unique_ptr<math::random::Distribution>
       distribution;  //> A pointer to the current distribution
@@ -40,16 +48,11 @@ class RandomOrConstant {
   float gen_random_number();
 
  public:
-  float constant, min_value, max_value;
-  float rand_min, rand_max;
-  float scale_factor = 1;
-
   math::random::RNG_Algorithm next_algorithm =
       math::random::RNG_Algorithm::DEFAULT;
   math::random::RNG_Distribution next_distribution =
       math::random::RNG_Distribution::UNIFORM;
 
-  bool use_random = false;
   RandomOrConstant();
 
   /*! \brief Create a new random or constant.

--- a/src/rendering/draw.cpp
+++ b/src/rendering/draw.cpp
@@ -13,6 +13,31 @@ void FillBuffer(const float* vertices,
   glVertexAttribPointer(attribute_id, 3, GL_FLOAT, GL_FALSE, 0, 0);
 }
 
+void ResizeBuffer(int vbo_id, int attribute_id, int size) {
+  glBindBuffer(GL_ARRAY_BUFFER, vbo_id);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(float) * size, nullptr, GL_DYNAMIC_DRAW);
+  glVertexAttribPointer(attribute_id, 3, GL_FLOAT, GL_FALSE, 0, 0);
+}
+
+float* MapBuffer(int vbo_id) {
+  // Bind the buffer
+  glBindBuffer(GL_ARRAY_BUFFER, vbo_id);
+  // map it and return the pointer
+  return reinterpret_cast<float*>(glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY));
+}
+
+float* MapBuffer(int vbo_id, int num_elements) {
+  glBindBuffer(GL_ARRAY_BUFFER, vbo_id);
+
+  return reinterpret_cast<float*>(
+      glMapBufferRange(GL_ARRAY_BUFFER, 0, num_elements, GL_MAP_WRITE_BIT));
+}
+
+void UnmapBuffer(int vbo_id) {
+  glBindBuffer(GL_ARRAY_BUFFER, vbo_id);
+  glUnmapBuffer(GL_ARRAY_BUFFER);
+}
+
 void EnableVertexAttribute(int vertex_attribute) {
   glEnableVertexAttribArray(vertex_attribute);
 }

--- a/src/rendering/draw.h
+++ b/src/rendering/draw.h
@@ -18,7 +18,7 @@ void DrawPoints(int num);
 
 /*! \brief Set up attribute to be drawn next draw call */
 template <typename T>
-inline void HandleAttribute(const T& ent, const ShaderAttribute& attr) {
+inline void HandleAttribute(T& ent, const ShaderAttribute& attr) {
   // Enable the vertex attribute for this shader
   const int attr_id = attr.id;
   EnableVertexAttribute(attr.id);
@@ -26,14 +26,14 @@ inline void HandleAttribute(const T& ent, const ShaderAttribute& attr) {
   // Fill the buffer with the asked for information
   switch (attr.T) {
     case (ShaderAttribute::type::vertex): {
-      const std::vector<float> vertex_buffer = ent.GetVertexBuffer();
+      const std::vector<float>& vertex_buffer = ent.GetVertexBuffer();
       const int num_vertices = ent.NumVertices();
 
       FillBuffer(vertex_buffer.data(), num_vertices, attr.vbo, attr_id);
       break;
     }
     case (ShaderAttribute::type::color): {
-      const std::vector<float> color_buffer = ent.GetColorBuffer();
+      const std::vector<float>& color_buffer = ent.GetColorBuffer();
       const int num_vertices = ent.NumVertices();
 
       FillBuffer(color_buffer.data(), num_vertices, attr.vbo, attr_id);
@@ -46,7 +46,7 @@ inline void HandleAttribute(const T& ent, const ShaderAttribute& attr) {
 }
 
 template <typename T>
-inline void Draw(const T& ent, const Shader& shader) {
+inline void Draw(T& ent, const Shader& shader) {
   // Fill buffers and enable each attribute
   UseProgram(shader.get_program_id());
 

--- a/src/rendering/draw.h
+++ b/src/rendering/draw.h
@@ -21,7 +21,7 @@ template <typename T>
 inline void HandleAttribute(T& ent, const ShaderAttribute& attr) {
   // Enable the vertex attribute for this shader
   const int attr_id = attr.id;
-  EnableVertexAttribute(attr.id);
+  // EnableVertexAttribute(attr.id);
 
   // Fill the buffer with the asked for information
   switch (attr.T) {
@@ -57,8 +57,8 @@ inline void Draw(T& ent, const Shader& shader) {
   DrawPoints(ent.NumVertices());
 
   // Disable all attributes
-  for (const auto& attr : shader.attributes)
-    DisableVertexAttribute(attr.id);
+  // for (const auto& attr : shader.attributes)
+  // DisableVertexAttribute(attr.id);
 }
 
 }  // namespace rpg::rendering

--- a/src/rendering/draw.h
+++ b/src/rendering/draw.h
@@ -3,6 +3,8 @@
 
 #include <vector>
 #include <cassert>
+#include <concepts>
+#include <execution>
 
 namespace rpg::rendering {
 
@@ -11,54 +13,86 @@ void FillBuffer(const float* vertices,
                 int num_elements,
                 int vbo_id,
                 int attribute_id);
+
+/*! \brief Unmap prior ptr, map the new ptr. */
+float* MapBuffer(int vbo_id);
+float* MapBuffer(int vbo_id, int num_elements);
+void ResizeBuffer(int vbo_id, int attribute_id, int size);
+void UnmapBuffer(int vbo_id);
+
 void EnableVertexAttribute(int vertex_attribute);
 void DisableVertexAttribute(int vertex_attribute);
 void UseProgram(int program_id);
 void DrawPoints(int num);
 
-/*! \brief Set up attribute to be drawn next draw call */
 template <typename T>
-inline void HandleAttribute(T& ent, const ShaderAttribute& attr) {
-  // Enable the vertex attribute for this shader
-  const int attr_id = attr.id;
-  // EnableVertexAttribute(attr.id);
+concept mappable_entity = requires(T e) {
+  { e.MaxVertices() }
+  ->std::integral;
+};
 
+template <typename T>
+inline const std::vector<float>& GetBufferFromAttribute(
+    T& ent,
+    const ShaderAttribute& attr) {
   // Fill the buffer with the asked for information
   switch (attr.T) {
-    case (ShaderAttribute::type::vertex): {
-      const std::vector<float>& vertex_buffer = ent.GetVertexBuffer();
-      const int num_vertices = ent.NumVertices();
-
-      FillBuffer(vertex_buffer.data(), num_vertices, attr.vbo, attr_id);
+    case (ShaderAttribute::type::vertex):
+      return ent.GetVertexBuffer();
       break;
-    }
-    case (ShaderAttribute::type::color): {
-      const std::vector<float>& color_buffer = ent.GetColorBuffer();
-      const int num_vertices = ent.NumVertices();
-
-      FillBuffer(color_buffer.data(), num_vertices, attr.vbo, attr_id);
+    case (ShaderAttribute::type::color):
+      return ent.GetColorBuffer();
       break;
-    }
     default:
       assert(false);
       break;
   }
 }
 
+/*! \brief Set up attribute to be drawn next draw call */
 template <typename T>
-inline void Draw(T& ent, const Shader& shader) {
+inline void HandleAttribute(T& ent, ShaderAttribute& attr) {
+  // Get a reference to the vector containing buffer info to insert
+  const std::vector<float>& buffer_to_insert =
+      GetBufferFromAttribute(ent, attr);
+
+  fill_or_map_buffer(ent, attr, buffer_to_insert);
+}
+
+inline void fill_or_map_buffer(const mappable_entity auto& ent,
+                               ShaderAttribute& attr,
+                               const std::vector<float>& buffer_to_insert) {
+  const int max_vertices = ent.MaxVertices();
+  const int num_vertices = ent.NumVertices();
+  // If the number of elements is larger than before, create a new buffer
+  if (max_vertices != attr.buffer_size) {
+    ResizeBuffer(attr.vbo, attr.id, max_vertices);
+    attr.buffer_size = max_vertices;
+  }
+
+  float* buffer_ptr = MapBuffer(attr.vbo, num_vertices);
+  std::copy_n(std::execution::par_unseq, buffer_to_insert.begin(), num_vertices,
+              buffer_ptr);
+  UnmapBuffer(attr.vbo);
+}
+
+template <typename T>
+inline void fill_or_map_buffer(const T& ent,
+                               ShaderAttribute& attr,
+                               const std::vector<float>& buffer_to_insert) {
+  FillBuffer(buffer_to_insert.data(), ent.NumVertices(), attr.vbo, attr.id);
+}
+
+template <typename T>
+inline void Draw(T& ent, Shader& shader) {
   // Fill buffers and enable each attribute
   UseProgram(shader.get_program_id());
 
-  for (const auto& attr : shader.attributes)
+  for (auto& attr : shader.attributes)
     HandleAttribute(ent, attr);
 
   // Draw points
-  DrawPoints(ent.NumVertices());
-
-  // Disable all attributes
-  // for (const auto& attr : shader.attributes)
-  // DisableVertexAttribute(attr.id);
+  DrawPoints(ent.NumVertices() / 3);
 }
 
 }  // namespace rpg::rendering

--- a/src/rendering/renderer.h
+++ b/src/rendering/renderer.h
@@ -18,7 +18,7 @@ class Renderer {
   /*! \brief Render the given entity */
   template <typename T>
   inline static void Render(T& ent) requires std::derived_from<T, Entity> {
-    const auto& shader = shader_manager.GetShaderforObject(ent.GetID());
+    auto& shader = shader_manager.GetShaderforObject(ent.GetID());
 
     Draw(ent, shader);
   }

--- a/src/rendering/renderer.h
+++ b/src/rendering/renderer.h
@@ -17,8 +17,7 @@ class Renderer {
  public:
   /*! \brief Render the given entity */
   template <typename T>
-  inline static void Render(
-      const T& ent) requires std::derived_from<T, Entity> {
+  inline static void Render(T& ent) requires std::derived_from<T, Entity> {
     const auto& shader = shader_manager.GetShaderforObject(ent.GetID());
 
     Draw(ent, shader);

--- a/src/rendering/shader.cpp
+++ b/src/rendering/shader.cpp
@@ -9,7 +9,8 @@ static const string fragment_ext = ".frag";
 namespace rpg::rendering {
 
 ShaderUniform::ShaderUniform(std::string name, type t) : T(t), name(name) {}
-ShaderAttribute::ShaderAttribute(std::string name, type t) : T(t), name(name) {}
+ShaderAttribute::ShaderAttribute(std::string name, type t)
+    : T(t), name(name), buffer_ptr(nullptr) {}
 
 /*! \brief Add an extension to the path if it doesn't have one */
 inline string add_path(const string& path, const string& extension) {
@@ -22,8 +23,11 @@ inline string add_path(const string& path, const string& extension) {
 
 Shader::Shader(const string& path,
                const vector<ShaderUniform>& uniforms,
-               const vector<ShaderAttribute>& attributes)
-    : uniforms(uniforms), attributes(attributes) {
+               const vector<ShaderAttribute>& attributes,
+               bool use_shared_buffers)
+    : uniforms(uniforms),
+      attributes(attributes),
+      use_mapped_buffers(use_shared_buffers) {
   this->fragment_path = add_path(path, fragment_ext);
   this->vertex_path = add_path(path, vertex_ext);
 };
@@ -31,7 +35,8 @@ Shader::Shader(const string& path,
 Shader::Shader(const string& vertex_path,
                const string& fragment_path,
                const vector<ShaderUniform>& uniforms,
-               const vector<ShaderAttribute>& attributes)
+               const vector<ShaderAttribute>& attributes,
+               bool use_shared_buffers)
     : uniforms(uniforms), attributes(attributes) {
   this->fragment_path = add_path(fragment_path, fragment_ext);
   this->vertex_path = add_path(vertex_path, vertex_ext);

--- a/src/rendering/shader.h
+++ b/src/rendering/shader.h
@@ -33,6 +33,8 @@ struct ShaderAttribute {
   std::string name;
   int id = -1;
   int vbo = -1;
+  int buffer_size = 0;
+  float* buffer_ptr;
 
   ShaderAttribute(std::string name, type t);
 };
@@ -41,6 +43,7 @@ struct ShaderAttribute {
 struct Shader {
  private:
   int program_id = -1;
+  bool use_mapped_buffers = false;
 
  public:
   std::string name;
@@ -52,12 +55,14 @@ struct Shader {
 
   Shader(const std::string& path,
          const std::vector<ShaderUniform>& uniforms,
-         const std::vector<ShaderAttribute>& attributes);
+         const std::vector<ShaderAttribute>& attributes,
+         bool use_shared_buffers = false);
 
   Shader(const std::string& vertex_path,
          const std::string& fragment_path,
          const std::vector<ShaderUniform>& uniforms,
-         const std::vector<ShaderAttribute>& attributes);
+         const std::vector<ShaderAttribute>& attributes,
+         bool use_shared_buffers = false);
 
   inline int get_program_id() const { return program_id; }
   inline void set_program_id(int new_id) { this->program_id = new_id; }

--- a/src/rendering/shader_manager.cpp
+++ b/src/rendering/shader_manager.cpp
@@ -32,6 +32,7 @@ void ShaderManager::CompileShader(Shader& shader) {
   for (auto& attribute : shader.attributes) {
     attribute.id = GetAttributeID(program_id, attribute.name);
     attribute.vbo = GenBuffer();
+    EnableVertexAttribute(attribute.id);
   }
 
   // Add it to our vector and name dictionary

--- a/src/rendering/shader_manager.cpp
+++ b/src/rendering/shader_manager.cpp
@@ -60,7 +60,7 @@ void ShaderManager::RegisterShader(int object_id, Shader& shader) {
   this->entity_map.insert({object_id, shader_id});
 }
 
-const Shader& ShaderManager::GetShaderforObject(int ent_id) const {
+Shader& ShaderManager::GetShaderforObject(int ent_id) {
   assert(this->entity_map.count(ent_id) > 0);
 
   return shaders[this->entity_map.at(ent_id)];

--- a/src/rendering/shader_manager.h
+++ b/src/rendering/shader_manager.h
@@ -30,10 +30,10 @@ class ShaderManager {
   void RegisterShader(int object_id, Shader& shader);
 
   /*! \brief Ge ta reference to the shader at a given ID */
-  const Shader& GetShader(int shader_id) const;
+  Shader& GetShader(int shader_id);
 
   /*! \brief Get the id of the shader assigned to a specific entity */
-  const Shader& GetShaderforObject(int ent_id) const;
+  Shader& GetShaderforObject(int ent_id);
 
   /*! \brief Update the MVP for every shader that needs it */
   void UpdateMVP(const float* MVP_ptr);

--- a/src/window/hud/combo.cpp
+++ b/src/window/hud/combo.cpp
@@ -15,7 +15,6 @@ std::string BuildString(const std::vector<std::string>& elements) {
     output.append("\0");
   }
 
-  std::cout << output << std::endl;
   return output;
 }
 
@@ -24,7 +23,7 @@ ComboBox::ComboBox(const std::string& name,
                    int* var)
     : Label(name, name), int_to_update(var), elements(elements) {
   this->values = BuildString(elements);
-  *int_to_update = 0;
+  this->last_value = *var;
 }
 
 ComboBox::ComboBox(const std::string& name,
@@ -36,7 +35,7 @@ ComboBox::ComboBox(const std::string& name,
       elements(elements),
       update_func(update_func) {
   this->values = BuildString(elements);
-  *int_to_update = 0;
+  this->last_value = *var;
 }
 
 void ComboBox::check_update(int new_value) {

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -141,6 +141,7 @@ GLFWwindow* InitWindow(float window_width, float window_height) {
   // Make the window resizable and update at 60 FPS
   glfwWindowHint(GLFW_RESIZABLE, GL_TRUE);
   glfwWindowHint(GLFW_REFRESH_RATE, 120);
+  glfwWindowHint(GLFW_SAMPLES, 16);
   glfwSetInputMode(window, GLFW_RAW_MOUSE_MOTION, GLFW_TRUE);
   glEnable(GL_PROGRAM_POINT_SIZE);
   glEnable(GL_BLEND);


### PR DESCRIPTION
# Optimization Pass 1
![image](https://user-images.githubusercontent.com/8203854/100255556-9ecb3880-2f11-11eb-9d6a-2883db20db38.png)

A variety of adjustments to improve overall program performance and the number of particles that can be simulated at any given time. In general, framerate has roughly been doubled, however Some issues still remain, and will be addressed in future changes. 

## Changes


### General
- Changed the particle limit and particles per second to cap out at 1 million particles. This can consistently hold 60 fps in most circumstances without coloring.
- Change compiler flags in cmake depending on the configuration used. Release no longer includes debugging information and enables more optimization flags, ReleaseWithDebug functions as the old release did, and debug enables only optimizations that don't harm debugging information. In general debugging is much faster than it used to be.

### Particle Engine
![image](https://user-images.githubusercontent.com/8203854/100255877-126d4580-2f12-11eb-8979-3e905c051fd4.png)

- Fix particle cap being 3x lower than it should be
- Rework the way that particles are created/destroyed. Now the particle system uses an array of particles that is only resized when the maximum amount of particles is changed. Upon update, only the particles that are alive are updated, and those that aren't alive are ignored. New particles replace dead ones instead of extending the size of the array. This removes the need to resize the particle array every frame, saving some valuable time.
- Vertex and color arrays are no longer created on demand, and are instead preallocated when whenever the main array is resized. Upon updating a particle, the particle's color and position arrays will be inserted into the vertex/color arrays that are directly sent to the GPU.
- Particles now internally use `std::array` instead of `glm::vec3`.
- Refactor particle coloring into several discrete functions. This allows for the minimum and maximum values of the color range to be calculated beforehand and reused for each particle.

### GUI
- Combo boxes no longer print all of their options on construction
- Combo boxes no longer set their variable to 0 on construction. 

### Math, Physics, Color
![image](https://user-images.githubusercontent.com/8203854/100911150-dbaca780-349c-11eb-9ebb-e085d901fdea.png)

- Vector3d's `set` and `get` functions now uses templates instead of requiring a switch statement, this removes the need for a branch any time these functions are called.
- Added a new concept for Vector3D to handle cases where a Vector3D could be accessed like a Vector3D struct and Vector3DArray. 
- Set several functions as constexpr, and add the Numeric constraint to more return values.
- Implement a new faster conversion from HSV to RGB at the cost of some precision using 8 bit integers. This makes the actual conversion faster, but limits the range of output colors resulting in some banding. I plan to revisit this in the future when I do another pass on color systems.
- Move ground collision check from rpg::simulation to simple_ground_bounce.
- Determine if particles are grounded earlier to improve performance when a large volume of particles are touching the ground. Note that the implementation still leaves room for improvement
- Split gravity calculations into multiple functions.
- Create a single helper function in physics that handles updating a particle's position, applying gravity, and handling collisions. 


### Rendering
- Only enable vertex attributes once per VAO. Previously it was enabling/disabling them with every draw call, which was unnecessary and potentially degraded performance.
- Implement the ability to reuse existing buffers for vertex attributes instead of creating new buffers every frame. This saves some time since the GPU isn't constantly reallocating its buffers every frame.
- Enable 16x multisampling (no affect right now).

## Closing comments
- Grounded particles still take up a lot of processing time. Some system to cache their status must be implemented, so particles on the ground (and eventually at rest) can have limited physics checks applied to them. 
- Coloring particles takes a relatively long time as well, this should be addressed in a future pr
- There is potential to use multiple threads for updating colors/physics/rendering in parallel, however that is out of the scope of this pr. 
